### PR TITLE
fix number format of memory peak usage on live page

### DIFF
--- a/src/Pinboard/Controller/server.php
+++ b/src/Pinboard/Controller/server.php
@@ -630,7 +630,7 @@ function getLivePages($conn, $serverName, $hostName, $lastId = null, $limit = 50
 
     foreach($data as &$item) {
         $item['req_time']        = number_format($item['req_time'] * 1000, 0, '.', ',');
-        $item['mem_peak_usage']  = $item['mem_peak_usage'];
+        $item['mem_peak_usage']  = number_format($item['mem_peak_usage'], 0, '.', ',');
     }
 
     return $data;


### PR DESCRIPTION
fix missing number format of memory peak on live page
