### PR TITLE
fix of fix #75 - Array of hosts for user access

### DIFF
--- a/src/Pinboard/Utils/Utils.php
+++ b/src/Pinboard/Utils/Utils.php
@@ -32,6 +32,7 @@ class Utils
         }
 
         $hasAccess = false;
+        $hostsRegExp = is_array($hostsRegExp) ? $hostsRegExp : array($hostsRegExp);
         foreach ($hostsRegExp as $regexp) {
             if (preg_match("/" . $regexp . "/", $serverName)) {
                 $hasAccess = true;


### PR DESCRIPTION
Fix. Error occurs when $hostsRegExp is string
