### PR TITLE
Request timers. Fix grouping

### DIFF
--- a/src/Pinboard/Controller/timer.php
+++ b/src/Pinboard/Controller/timer.php
@@ -63,7 +63,7 @@ $server->get('/{type}/{requestId}/{grouping}', function($type, $requestId, $grou
         'grouping_tags' => $groupingTags,
         'grouping' => $grouping,
         'type' => $type,
-        'request_id' => $requestId,
+        'request_id' => $requestId.'::'.$date,
     );
 
     return $app['twig']->render(


### PR DESCRIPTION
Fix. Not working "grouped by ... " on page Request timers.
