### PR TITLE
Autocreation of config file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,10 @@
         "symfony/twig-bridge": "~2.1",
         "symfony/console": "dev-master",
         "symfony/process": "dev-master",
-        "symfony/yaml": "dev-master",
+        "symfony/yaml": "2.*",
         "symfony/security": "2.3.*",
-        "swiftmailer/swiftmailer": ">=4.1.2,<4.2-dev"
+        "swiftmailer/swiftmailer": ">=4.1.2,<4.2-dev",
+        "incenteev/composer-parameter-handler": "~2.0"
     },
     "suggest": {
         "ext-apc": "Opcode cache. Improves Application performance."
@@ -34,6 +35,20 @@
     "autoload": {
         "psr-0": {
             "Pinboard": "src/"
+        }
+    },
+    "scripts": {
+        "post-install-cmd": [
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters"
+        ],
+        "post-update-cmd": [
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters"
+        ]
+    },
+    "extra": {
+        "incenteev-parameters": {
+            "file": "config/parameters.yml",
+            "parameter-key": "db"
         }
     }
 }


### PR DESCRIPTION
This fix enable automatic config creation using `config/parameters.yml.dist` as template. Unfortunately, due to module limitations and because of many config vars are on first level, currently only database connection info asked. All other vars will be copied as is. And if you add something to template file, it will be added to generated config.
