### PR TITLE
 + allow use timers with special chars in name

### DIFF
--- a/views/timer.html.twig
+++ b/views/timer.html.twig
@@ -44,10 +44,10 @@
                 rtChart = null;
                 rtChartData = [{
                     {% for k, v in request.timers %}
-                    {{ k }}: "{{ v.value }}"{{ loop.revindex0 > 0 ? ',' : '' }}
+                    "{{ k }}": "{{ v.value }}"{{ loop.revindex0 > 0 ? ',' : '' }}
                     {% endfor %}
                     {% if request.req_time_other is defined %}
-                    , other: "{{ request.req_time_other }}"
+                    , "other": "{{ request.req_time_other }}"
                     {% endif %}
                 }];
 


### PR DESCRIPTION
We use timers with names like `controller@method` and JS on page `Request timers` triggers an error. As i know any string can be object key in JS.