### PR TITLE
Downgrade version of symfony/console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "doctrine/migrations": "dev-master",
         "twig/twig": ">=1.8,<2.0-dev",
         "symfony/twig-bridge": "~2.1",
-        "symfony/console": "dev-master",
+        "symfony/console": "2.*",
         "symfony/process": "dev-master",
         "symfony/yaml": "2.*",
         "symfony/security": "2.3.*",


### PR DESCRIPTION
DialogHelper is deprecated since version 2.5, and already removed in dev-master.