### PR TITLE
Quick fix for IDN.

### DIFF
--- a/src/Pinboard/Controller/server.php
+++ b/src/Pinboard/Controller/server.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Pinboard\Command\AggregateCommand;
+use Pinboard\Utils\IDNaConvert;
 
 $ROW_PER_PAGE = 50;
 $rowPerPage = isset($app['params']['pagination']['row_per_page']) ? $app['params']['pagination']['row_per_page'] : $ROW_PER_PAGE;
@@ -16,6 +17,9 @@ $server = $app['controllers_factory'];
 $allowedPeriods = array('1 day', '3 days', '1 week', '1 month');
 
 $server->get('/{serverName}/{hostName}/overview.{format}', function(Request $request, $serverName, $hostName, $format) use ($app, $allowedPeriods) {
+    $idn = new IDNaConvert(array('idn_version' => 2008));
+    $serverName = $idn->encode($serverName);
+
     Utils::checkUserAccess($app, $serverName);
 
     $period = $request->get('period', '1 day');


### PR DESCRIPTION
This is a quick fix for IDN.

Pinboard converts server names to idn version from punycode on the index page. But if you try to go deeper to exact server pinboard fails to do so. This is a quick fix for that, to be able to show pages with uri like the following:
http://pinboard.lan/server/сайт.рф/all/overview