### PR TITLE
fix #131 Incorrect pagination on Request time page

### DIFF
--- a/src/Pinboard/Controller/server.php
+++ b/src/Pinboard/Controller/server.php
@@ -707,7 +707,7 @@ function getSlowPagesCount($conn, $serverName, $hostName) {
 
     $sql = '
         SELECT
-            COUNT(*)
+            COUNT(DISTINCT request_id) cnt
         FROM
             ipm_req_time_details
         WHERE
@@ -718,7 +718,7 @@ function getSlowPagesCount($conn, $serverName, $hostName) {
 
     $data = $conn->fetchAll($sql, $params);
 
-    return (int)$data[0]['COUNT(*)'];
+    return (int)$data[0]['cnt'];
 }
 
 function getSlowPages($conn, $serverName, $hostName, $startPos, $rowCount, $colOrder, $colDir) {


### PR DESCRIPTION
Query for calculating amount of slow pages works without DISTINCT, but query for getting list of slow pages uses DISTINCT. This leads to the appearance of extra pages.
