### PR TITLE
chore(ci): upgrade actions/checkout and actions/cache to v5 (Node.js 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: PHP CS Fixer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -24,7 +24,7 @@ jobs:
           extensions: intl, pdo_mysql
           coverage: none
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: composer-8.4-${{ hashFiles('composer.lock') }}
@@ -38,7 +38,7 @@ jobs:
     name: PHPStan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -46,7 +46,7 @@ jobs:
           extensions: intl, pdo_mysql
           coverage: none
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: composer-8.4-${{ hashFiles('composer.lock') }}
@@ -62,7 +62,7 @@ jobs:
           DATABASE_URL: mysql://pinba:pinba@127.0.0.1:3306/pinba?serverVersion=8.4.0
         run: php bin/console cache:warmup
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: var/phpstan
           key: phpstan-${{ hashFiles('phpstan.neon', 'composer.lock') }}
@@ -78,7 +78,7 @@ jobs:
       matrix:
         php: ['8.4', '8.5']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -86,7 +86,7 @@ jobs:
           extensions: intl, pdo_mysql
           coverage: none
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build and push Docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary

- Replace `actions/checkout@v4` and `actions/cache@v4` with `@v5` across all workflows
- Eliminates Node.js 20 deprecation warnings; Node.js 20 runners are removed September 2026

## Test plan

- [ ] CI jobs run without Node.js 20 deprecation warnings