### PR TITLE
fix(ci): set last-release-sha so release-please finds its anchor

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "last-release-sha": "0e25cdab68175194ed7ac67c0391c95154b31dad",
   "changelog-path": "CHANGELOG.md",
   "bump-patch-for-minor-pre-major": false,
   "changelog-sections": [


### PR DESCRIPTION
## Summary

Release Please was not creating a Release PR because it couldn't find a SHA anchor for `v2.0.0`. The release was created manually (not by release-please), so it has no `autorelease: tagged` label that release-please uses to locate the last release commit.

Fix: add `last-release-sha` to `release-please-config.json` pointing to the merge commit of PR #147 (the commit tagged as `v2.0.0`). After release-please successfully creates and merges its first Release PR, it will manage the anchor itself going forward — this field can be removed.

## Test plan

- [ ] After merge, release-please workflow runs and opens a Release PR for `2.1.0`