### PR TITLE
fix(ci): set explicit component to match release tag format

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
-  "changelog-path": "CHANGELOG.md",
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "changelog-path": "CHANGELOG.md",
+      "component": ""
+    }
+  },
   "bump-patch-for-minor-pre-major": false,
   "changelog-sections": [
     {"type": "feat",     "section": "Features"},


### PR DESCRIPTION
## Summary

release-please v17 extracts component `''` (empty string) from tags like `v2.1.0`. The root package path `"."` in the manifest doesn't automatically map to empty component, causing `Set(0)` on every run and no Release PR ever being created.

Fix: restructure config to use `packages: {".": {"component": ""}}` — this explicitly declares that the root package has an empty component, matching the tag format.

Also: v2.1.0 GitHub Release has been created manually at tag `b6c82cf` to bootstrap the anchor.

## Test plan

- [ ] After merge, release-please workflow runs and finds `v2.1.0` as the anchor (no `Set(0)`)
- [ ] On the next `feat` or `fix` PR merge, release-please creates a Release PR automatically