### PR TITLE
fix(ui): align request time pagination count

### DIFF
--- a/src/Controller/ServerController.php
+++ b/src/Controller/ServerController.php
@@ -906,7 +906,7 @@ class ServerController extends AbstractController
 
         $sql = "
             SELECT
-                COUNT(*)
+                COUNT(DISTINCT request_id)
             FROM
                 ipm_req_time_details
             WHERE


### PR DESCRIPTION
## Summary
Fix request-time pagination to count the same unique rows that are shown in the list.

## Root cause
The Request time page fetched rows with DISTINCT but used COUNT(*) for pagination. When duplicate rows existed in ipm_req_time_details, the UI could show extra pages.

## Change
Use COUNT(DISTINCT request_id) in the request-time counter so pagination matches the result set.

## Validation
- php -l src/Controller/ServerController.php
- vendor/bin/phpstan analyse --no-progress src/Controller/ServerController.php
- vendor/bin/phpunit --no-progress