### PR TITLE
fix(ci): trigger docker publish from release automation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,12 @@ name: Docker
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: 'Release tag to publish, for example v2.1.2. Leave empty to use the current ref.'
+        required: false
+        type: string
 
 jobs:
   build-push:
@@ -10,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.release-tag != '' && inputs.release-tag || github.ref }}
 
       - uses: docker/setup-buildx-action@v3
 
@@ -21,7 +29,7 @@ jobs:
       - name: Extract version from tag
         id: meta
         run: |
-          TAG="${{ github.ref_name }}"
+          TAG="${{ inputs.release-tag != '' && inputs.release-tag || github.ref_name }}"
           VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: rp
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           release-as: ${{ inputs.release-as }}


### PR DESCRIPTION
## Summary
Use a dedicated GitHub token for Release Please and add a manual Docker publish path by tag.

## Root cause
Release Please was using the default GITHUB_TOKEN. Releases created by that token do not trigger follow-up workflows, so the Docker publish workflow did not run for v2.1.2.

## Changes
- configure release-please to use secrets.RELEASE_PLEASE_TOKEN
- add workflow_dispatch to the Docker workflow
- allow the Docker workflow to publish a specific release tag manually

## Validation
- inspected current release and workflow behavior for v2.1.2
- verified repository secrets exist
- confirmed previous Docker publish worked for v2.1.0 and that v2.1.2 did not trigger a Docker run before this fix