### PR TITLE
fix(db): retain tag info with cleanup

### DIFF
--- a/migrations/Version20260530160000.php
+++ b/migrations/Version20260530160000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260530160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add created_at index for ipm_tag_info retention cleanup';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("
+            ALTER TABLE `ipm_tag_info` ADD INDEX `iti_c` (`created_at`);
+        ");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("
+            ALTER TABLE `ipm_tag_info` DROP INDEX `iti_c`;
+        ");
+    }
+}

--- a/src/Command/AggregateCommand.php
+++ b/src/Command/AggregateCommand.php
@@ -323,6 +323,7 @@ class AggregateCommand extends Command
             'ipm_status_details',
             'ipm_cpu_usage_details',
             'ipm_timer',
+            'ipm_tag_info',
         ];
 
         $sql = '';


### PR DESCRIPTION
## Summary
Keep ipm_tag_info under the same retention policy as the other aggregated tables and add an index on created_at for efficient cleanup.

## Why
ipm_tag_info is populated on every aggregation run and is queried with a created_at window in the UI, but it was not included in the retention cleanup list. That means the table would keep growing past the configured APP_RECORDS_LIFETIME even though the rest of the aggregate tables are pruned.

## Change
- add ipm_tag_info to the aggregation cleanup list
- add a migration that creates iti_c on ipm_tag_info(created_at) so cleanup does not scan the whole table

## Validation
- php -l src/Command/AggregateCommand.php
- php -l migrations/Version20260530160000.php
- vendor/bin/phpstan analyse --no-progress src/Command/AggregateCommand.php migrations/Version20260530160000.php
- vendor/bin/phpunit --no-progress

## Local data check
- ipm_tag_info exists in the local pinba database and is populated by the current aggregator
- the table already has rows older than 14 days, so retention is relevant under the configured P1M lifetime
