### PR TITLE
fix(aggregate): release lock on failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 - PHP style: `vendor/bin/php-cs-fixer fix --dry-run --diff` — fix violations with `vendor/bin/php-cs-fixer fix`.
 - PHP static analysis: `vendor/bin/phpstan analyse --no-progress` — runs at **level 10** (maximum).
 - Frontend rebuild: `pnpm build`.
+- Before pushing or opening a PR with PHP code changes, run `vendor/bin/php-cs-fixer fix --dry-run --diff` and `vendor/bin/phpstan analyse --no-progress` locally.
 - Prefer focused verification over broad test runs unless the change spans multiple layers.
 
 ## PHP Static Analysis Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ All changes enter `master` exclusively via pull request — direct pushes are bl
 
 - Branch names: `fix/description`, `feat/description`, `chore/description`, etc.
 - Commit titles must follow Conventional Commits (see `docs/contributing.md`).
+- Pull request titles must also follow Conventional Commits.
+- Do not add extra prefixes to pull request titles, for example `[codex]` or similar tooling markers.
 - CI runs three mandatory jobs: `PHP CS Fixer`, `PHPStan`, `PHPUnit (8.4 + 8.5)`.
 - After a PR merges, Release Please automatically opens or updates a Release PR.
 - Merging the Release PR creates a `vX.Y.Z` tag and GitHub Release.

--- a/docker-compose.public.yml
+++ b/docker-compose.public.yml
@@ -103,7 +103,6 @@ services:
       APP_NOTIFICATION_ENABLE: ${APP_NOTIFICATION_ENABLE:-0}
       APP_NOTIFICATION_SENDER: ${APP_NOTIFICATION_SENDER:-noreply@pinboard.local}
       APP_NOTIFICATION_GLOBAL_EMAIL: ${APP_NOTIFICATION_GLOBAL_EMAIL:-}
-      APP_AGGREGATE_LOCK_TTL_SECONDS: "900"
     command: ["supercronic", "/etc/crontabs/aggregate.cron"]
     volumes:
       - pinboard-var:/var/www/var

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,10 +31,10 @@ pnpm build
 ## Example crontab entry
 
 ```cron
-*/15 * * * * cd /var/www/pinboard/current && php bin/console aggregate --no-interaction >> /var/log/pinboard/aggregate.log 2>&1
+*/15 * * * * cd /var/www/pinboard/current && /usr/bin/php8.4 bin/console aggregate --no-interaction >> /var/log/pinboard/aggregate.log 2>&1
 ```
 
-This runs aggregation every 15 minutes and writes output to a log file. Adjust paths to match your environment.
+This runs aggregation every 15 minutes and writes output to a log file. Adjust paths to match your environment, and use the exact PHP 8.4+ binary configured for this installation rather than relying on cron's `PATH`.
 
 ## Data visibility timeline
 

--- a/src/Command/AggregateCommand.php
+++ b/src/Command/AggregateCommand.php
@@ -25,7 +25,6 @@ class AggregateCommand extends Command
     public const float DEFAULT_SLOW_REQ_TIME = 1.5;
     public const int DEFAULT_HEAVY_PAGE_MEMORY = 30000;
     public const int DEFAULT_HEAVY_PAGE_CPU = 1;
-    public const int DEFAULT_LOCK_TTL_SECONDS = 900;
     public const int DEFAULT_MIN_ERROR_CODE = 500;
 
     public function __construct(
@@ -262,109 +261,108 @@ class AggregateCommand extends Command
         }
 
         $lockFile = $this->projectDir . '/var/aggregate.lock';
-        $lockTtlSeconds = $this->envInt('APP_AGGREGATE_LOCK_TTL_SECONDS', self::DEFAULT_LOCK_TTL_SECONDS);
-        if (file_exists($lockFile)) {
-            $mtime = @filemtime($lockFile);
-            if ($mtime !== false && (time() - $mtime) > $lockTtlSeconds) {
-                if (@unlink($lockFile)) {
-                    $output->writeln(sprintf(
-                        '<comment>Removed stale lock file %s (older than %d seconds).</comment>',
-                        $lockFile,
-                        $lockTtlSeconds
-                    ));
-                } else {
-                    $output->writeln(sprintf(
-                        '<error>Found stale lock file %s, but cannot remove it. Please remove it manually.</error>',
-                        $lockFile
-                    ));
+        $lockHandle = @fopen($lockFile, 'c+');
+        if ($lockHandle === false) {
+            $output->writeln('<error>Cannot open lock file ' . $lockFile . '</error>');
 
-                    return Command::FAILURE;
-                }
-            }
+            return Command::FAILURE;
         }
 
-        if (file_exists($lockFile)) {
-            $output->writeln('<error>Cannot run data aggregation: another instance is already executing. Otherwise, remove ' . $lockFile . '</error>');
+        if (!flock($lockHandle, LOCK_EX | LOCK_NB)) {
+            $output->writeln('<error>Cannot run data aggregation: another instance is already executing.</error>');
 
             if ($this->config->notificationGlobalEmail !== '') {
                 try {
                     $body = $this->twig->render('lock_notification.html.twig');
                     $this->sendEmail($this->config->notificationGlobalEmail, 'Intaro Pinboard can\'t run data aggregation', $body);
-                } catch (Exception $e) {
+                } catch (\Throwable $e) {
                     $output->writeln('<error>Failed to send lock notification: ' . $e->getMessage() . '</error>');
                 }
             }
 
+            fclose($lockHandle);
+
             return Command::FAILURE;
         }
 
-        if (!touch($lockFile)) {
-            $output->writeln('<error>Warning: cannot create ' . $lockFile . '</error>');
+        $lockMetadata = sprintf(
+            "pid=%d\nstarted_at=%s\n",
+            getmypid() ?: 0,
+            date(DATE_ATOM)
+        );
+        if (
+            ftruncate($lockHandle, 0) === false ||
+            rewind($lockHandle) === false ||
+            fwrite($lockHandle, $lockMetadata) === false ||
+            fflush($lockHandle) === false
+        ) {
+            $output->writeln('<comment>Warning: failed to write lock metadata to ' . $lockFile . '</comment>');
         }
 
-        $now = new \DateTime();
-        $now = $now->format('Y-m-d H:i:s');
+        try {
+            $now = new \DateTime();
+            $now = $now->format('Y-m-d H:i:s');
 
-        $delta = new \DateInterval($this->config->recordsLifetime !== '' ? $this->config->recordsLifetime : 'P1M');
-        $date = new \DateTime();
-        $date->sub($delta);
+            $delta = new \DateInterval($this->config->recordsLifetime !== '' ? $this->config->recordsLifetime : 'P1M');
+            $date = new \DateTime();
+            $date->sub($delta);
 
-        $params = [
-            'created_at' => $date->format('Y-m-d H:i:s'),
-        ];
+            $params = [
+                'created_at' => $date->format('Y-m-d H:i:s'),
+            ];
 
-        $tablesForClear = [
-            'ipm_report_2_by_hostname_and_server',
-            'ipm_report_by_hostname',
-            'ipm_report_by_hostname_and_server',
-            'ipm_report_by_server_name',
-            'ipm_req_time_details',
-            'ipm_mem_peak_usage_details',
-            'ipm_status_details',
-            'ipm_cpu_usage_details',
-            'ipm_timer',
-            'ipm_tag_info',
-        ];
+            $tablesForClear = [
+                'ipm_report_2_by_hostname_and_server',
+                'ipm_report_by_hostname',
+                'ipm_report_by_hostname_and_server',
+                'ipm_report_by_server_name',
+                'ipm_req_time_details',
+                'ipm_mem_peak_usage_details',
+                'ipm_status_details',
+                'ipm_cpu_usage_details',
+                'ipm_timer',
+                'ipm_tag_info',
+            ];
 
-        $sql = '';
+            $sql = '';
 
-        foreach ($tablesForClear as $value) {
-            $sql .= '
-            DELETE
-            FROM
-                ' . $value . '
-            WHERE
-                created_at < :created_at
-            ;';
-        }
-        $db->executeStatement($sql, $params);
-
-        if ($this->config->notificationEnable) {
-            $sql = '
-                SELECT
-                    server_name, script_name, status, max(hostname) AS hostname, count(*) AS count
+            foreach ($tablesForClear as $value) {
+                $sql .= '
+                DELETE
                 FROM
-                    request
+                    ' . $value . '
                 WHERE
-                    status >= ' . $this->config->minErrorCode . '
-                GROUP BY
-                    server_name, script_name, status
-            ';
+                    created_at < :created_at
+                ;';
+            }
+            $db->executeStatement($sql, $params);
 
-            $errorPages = $db->executeQuery($sql)->fetchAllAssociative();
+            if ($this->config->notificationEnable) {
+                $sql = '
+                    SELECT
+                        server_name, script_name, status, max(hostname) AS hostname, count(*) AS count
+                    FROM
+                        request
+                    WHERE
+                        status >= ' . $this->config->minErrorCode . '
+                    GROUP BY
+                        server_name, script_name, status
+                ';
 
-            if (count($errorPages) > 0) {
-                try {
-                    $this->sendErrorEmails($errorPages);
-                } catch (Exception $e) {
-                    $output->writeln("<error>Notification sending error\n" . $e->getMessage() . '</error>');
+                $errorPages = $db->executeQuery($sql)->fetchAllAssociative();
+
+                if (count($errorPages) > 0) {
+                    try {
+                        $this->sendErrorEmails($errorPages);
+                    } catch (Exception $e) {
+                        $output->writeln("<error>Notification sending error\n" . $e->getMessage() . '</error>');
+                    }
                 }
+
+                unset($errorPages);
             }
 
-            unset($errorPages);
-        }
-
-        $db->beginTransaction();
+            $db->beginTransaction();
 
         $sql = '
             SELECT
@@ -763,13 +761,15 @@ class AggregateCommand extends Command
         $values = $this->getBorderOutValues($db, $servers);
         $this->sendBorderOutEmails($values);
 
-        $output->writeln('<info>Data are aggregated successfully</info>');
+            $output->writeln('<info>Data are aggregated successfully</info>');
 
-        if (file_exists($lockFile) && !unlink($lockFile)) {
-            $output->writeln('<error>Error: cannot remove ' . $lockFile . ' file, you must remove it manually and check server settings.</error>');
+            return Command::SUCCESS;
+        } finally {
+            ftruncate($lockHandle, 0);
+            fflush($lockHandle);
+            flock($lockHandle, LOCK_UN);
+            fclose($lockHandle);
         }
-
-        return Command::SUCCESS;
     }
 
 

--- a/src/Command/AggregateCommand.php
+++ b/src/Command/AggregateCommand.php
@@ -364,7 +364,7 @@ class AggregateCommand extends Command
 
             $db->beginTransaction();
 
-        $sql = '
+            $sql = '
             SELECT
                 server_name, hostname, COUNT(*) AS cnt
             FROM
@@ -373,9 +373,9 @@ class AggregateCommand extends Command
                 server_name, hostname
         ';
 
-        $servers = $db->executeQuery($sql)->fetchAllAssociative();
+            $servers = $db->executeQuery($sql)->fetchAllAssociative();
 
-        $subselectTemplate = '
+            $subselectTemplate = '
             (
                 SELECT
                     r.%s
@@ -389,17 +389,17 @@ class AggregateCommand extends Command
             as %s
         ';
 
-        $sql = '';
-        foreach ($servers as $server) {
-            $serverName = is_string($server['server_name']) ? $server['server_name'] : '';
-            $hostName = is_string($server['hostname']) ? $server['hostname'] : '';
-            $cnt = is_numeric($server['cnt']) ? (int) $server['cnt'] : 0;
-            if ($serverName === '' || $hostName === '' || $cnt === 0) {
-                continue;
-            }
-            $serverNameEsc = addslashes($serverName);
-            $hostNameEsc = addslashes($hostName);
-            $sql .= '
+            $sql = '';
+            foreach ($servers as $server) {
+                $serverName = is_string($server['server_name']) ? $server['server_name'] : '';
+                $hostName = is_string($server['hostname']) ? $server['hostname'] : '';
+                $cnt = is_numeric($server['cnt']) ? (int) $server['cnt'] : 0;
+                if ($serverName === '' || $hostName === '' || $cnt === 0) {
+                    continue;
+                }
+                $serverNameEsc = addslashes($serverName);
+                $hostNameEsc = addslashes($hostName);
+                $sql .= '
                 INSERT INTO ipm_report_2_by_hostname_and_server
                     (server_name, hostname, req_time_90, req_time_95, req_time_99, req_time_100,
                      mem_peak_usage_90, mem_peak_usage_95, mem_peak_usage_99, mem_peak_usage_100,
@@ -430,14 +430,14 @@ class AggregateCommand extends Command
                 WHERE
                     r2.server_name = "' . $serverNameEsc . '" and r2.hostname = "' . $hostNameEsc . '"
             ;';
-        }
-        if ($sql !== '') {
-            $db->executeStatement($sql);
-        }
+            }
+            if ($sql !== '') {
+                $db->executeStatement($sql);
+            }
 
-        $db->commit();
+            $db->commit();
 
-        $sql = '
+            $sql = '
             INSERT INTO ipm_report_by_hostname
                 (
                     req_count, req_per_sec, req_time_total, req_time_percent, req_time_per_sec,
@@ -480,10 +480,10 @@ class AggregateCommand extends Command
                     traffic_total, traffic_percent, traffic_per_sec,
                     server_name, req_time_median, p90, p95, p99, \'' . $now . '\' FROM ipm_pinba_report_by_server_90_95_99;
         ';
-        $db->executeStatement($sql);
+            $db->executeStatement($sql);
 
-        //insert timers reports
-        $sql = '
+            //insert timers reports
+            $sql = '
             INSERT INTO ipm_tag_info
                 (
                     `group`, server_name, req_count, req_per_sec, hit_count,
@@ -572,9 +572,9 @@ class AggregateCommand extends Command
             FROM
                 ipm_pinba_tag_info_category_server_server_name_hostname;
         ';
-        $db->executeStatement($sql);
+            $db->executeStatement($sql);
 
-        $sql = '
+            $sql = '
             INSERT INTO
                 ipm_status_details (server_name, hostname, script_name, status, tags, tags_cnt, created_at)
             SELECT
@@ -588,24 +588,24 @@ class AggregateCommand extends Command
             LIMIT
                 25
         ';
-        $db->executeStatement($sql);
+            $db->executeStatement($sql);
 
-        $maxReqId = $db->fetchOne('SELECT max(id) FROM ipm_req_time_details');
+            $maxReqId = $db->fetchOne('SELECT max(id) FROM ipm_req_time_details');
 
-        $sql = '';
-        foreach ($servers as $server) {
-            $serverName = is_string($server['server_name']) ? $server['server_name'] : '';
-            $hostName = is_string($server['hostname']) ? $server['hostname'] : '';
-            if ($serverName === '' || $hostName === '') {
-                continue;
-            }
-            $serverNameEsc = addslashes($serverName);
-            $hostNameEsc = addslashes($hostName);
-            $maxReqTime = $this->config->longRequestTime['global'] ?? static::DEFAULT_SLOW_REQ_TIME;
-            if (isset($this->config->longRequestTime[$serverName])) {
-                $maxReqTime = $this->config->longRequestTime[$serverName];
-            }
-            $sql .= '
+            $sql = '';
+            foreach ($servers as $server) {
+                $serverName = is_string($server['server_name']) ? $server['server_name'] : '';
+                $hostName = is_string($server['hostname']) ? $server['hostname'] : '';
+                if ($serverName === '' || $hostName === '') {
+                    continue;
+                }
+                $serverNameEsc = addslashes($serverName);
+                $hostNameEsc = addslashes($hostName);
+                $maxReqTime = $this->config->longRequestTime['global'] ?? static::DEFAULT_SLOW_REQ_TIME;
+                if (isset($this->config->longRequestTime[$serverName])) {
+                    $maxReqTime = $this->config->longRequestTime[$serverName];
+                }
+                $sql .= '
                 INSERT INTO ipm_req_time_details
                     (request_id, server_name, hostname, script_name, req_time, mem_peak_usage, tags, tags_cnt, timers_cnt, created_at)
                 SELECT
@@ -639,11 +639,11 @@ class AggregateCommand extends Command
                 LIMIT
                     10
             ;';
-        }
-        if ($sql !== '') {
-            $db->executeStatement($sql);
+            }
+            if ($sql !== '') {
+                $db->executeStatement($sql);
 
-            $sql = '
+                $sql = '
                 SELECT
                     request_id
                 FROM
@@ -652,21 +652,21 @@ class AggregateCommand extends Command
                     id > :max_id
             ';
 
-            $data = $db->executeQuery($sql, ['max_id' => $maxReqId])->fetchAllAssociative();
+                $data = $db->executeQuery($sql, ['max_id' => $maxReqId])->fetchAllAssociative();
 
-            $ids = [];
-            foreach ($data as $item) {
-                $reqId = $item['request_id'];
-                if (is_int($reqId)) {
-                    $ids[] = (string) $reqId;
-                } elseif (is_string($reqId) && $reqId !== '') {
-                    $ids[] = $reqId;
+                $ids = [];
+                foreach ($data as $item) {
+                    $reqId = $item['request_id'];
+                    if (is_int($reqId)) {
+                        $ids[] = (string) $reqId;
+                    } elseif (is_string($reqId) && $reqId !== '') {
+                        $ids[] = $reqId;
+                    }
                 }
-            }
-            unset($data);
+                unset($data);
 
-            if (count($ids)) {
-                $sql = '
+                if (count($ids)) {
+                    $sql = '
                     INSERT INTO ipm_timer
                         (timer_id, request_id, hit_count, value, tag_name, tag_value, created_at)
                     SELECT
@@ -683,25 +683,25 @@ class AggregateCommand extends Command
                         t.request_id IN (' . implode(', ', $ids) . ')
                 ';
 
-                $db->executeStatement($sql);
-            }
-        }
-
-        $sql = '';
-        foreach ($servers as $server) {
-            $serverName = is_string($server['server_name']) ? $server['server_name'] : '';
-            $hostName = is_string($server['hostname']) ? $server['hostname'] : '';
-            if ($serverName === '' || $hostName === '') {
-                continue;
-            }
-            $serverNameEsc = addslashes($serverName);
-            $hostNameEsc = addslashes($hostName);
-            $maxMemoryUsage = $this->config->heavyRequest['global'] ?? static::DEFAULT_HEAVY_PAGE_MEMORY;
-            if (isset($this->config->heavyRequest[$serverName])) {
-                $maxMemoryUsage = $this->config->heavyRequest[$serverName];
+                    $db->executeStatement($sql);
+                }
             }
 
-            $sql .= '
+            $sql = '';
+            foreach ($servers as $server) {
+                $serverName = is_string($server['server_name']) ? $server['server_name'] : '';
+                $hostName = is_string($server['hostname']) ? $server['hostname'] : '';
+                if ($serverName === '' || $hostName === '') {
+                    continue;
+                }
+                $serverNameEsc = addslashes($serverName);
+                $hostNameEsc = addslashes($hostName);
+                $maxMemoryUsage = $this->config->heavyRequest['global'] ?? static::DEFAULT_HEAVY_PAGE_MEMORY;
+                if (isset($this->config->heavyRequest[$serverName])) {
+                    $maxMemoryUsage = $this->config->heavyRequest[$serverName];
+                }
+
+                $sql .= '
                 INSERT INTO ipm_mem_peak_usage_details
                     (server_name, hostname, script_name, mem_peak_usage, tags, tags_cnt, created_at)
                 SELECT
@@ -717,26 +717,26 @@ class AggregateCommand extends Command
                 LIMIT
                     10
             ;';
-        }
-        if ($sql !== '') {
-            $db->executeStatement($sql);
-        }
-
-        $sql = '';
-        foreach ($servers as $server) {
-            $serverName = is_string($server['server_name']) ? $server['server_name'] : '';
-            $hostName = is_string($server['hostname']) ? $server['hostname'] : '';
-            if ($serverName === '' || $hostName === '') {
-                continue;
             }
-            $serverNameEsc = addslashes($serverName);
-            $hostNameEsc = addslashes($hostName);
-            $maxCPUUsage = $this->config->heavyCpuRequest['global'] ?? static::DEFAULT_HEAVY_PAGE_CPU;
-            if (isset($this->config->heavyCpuRequest[$serverName])) {
-                $maxCPUUsage = $this->config->heavyCpuRequest[$serverName];
+            if ($sql !== '') {
+                $db->executeStatement($sql);
             }
 
-            $sql .= '
+            $sql = '';
+            foreach ($servers as $server) {
+                $serverName = is_string($server['server_name']) ? $server['server_name'] : '';
+                $hostName = is_string($server['hostname']) ? $server['hostname'] : '';
+                if ($serverName === '' || $hostName === '') {
+                    continue;
+                }
+                $serverNameEsc = addslashes($serverName);
+                $hostNameEsc = addslashes($hostName);
+                $maxCPUUsage = $this->config->heavyCpuRequest['global'] ?? static::DEFAULT_HEAVY_PAGE_CPU;
+                if (isset($this->config->heavyCpuRequest[$serverName])) {
+                    $maxCPUUsage = $this->config->heavyCpuRequest[$serverName];
+                }
+
+                $sql .= '
                   INSERT INTO ipm_cpu_usage_details
                       (server_name, hostname, script_name, cpu_peak_usage, tags, tags_cnt, created_at)
                   SELECT
@@ -752,14 +752,14 @@ class AggregateCommand extends Command
                   LIMIT
                       10
             ;';
-        }
-        if ($sql !== '') {
-            $db->executeStatement($sql);
-        }
+            }
+            if ($sql !== '') {
+                $db->executeStatement($sql);
+            }
 
-        // notification about abrupt drawdown of indicators
-        $values = $this->getBorderOutValues($db, $servers);
-        $this->sendBorderOutEmails($values);
+            // notification about abrupt drawdown of indicators
+            $values = $this->getBorderOutValues($db, $servers);
+            $this->sendBorderOutEmails($values);
 
             $output->writeln('<info>Data are aggregated successfully</info>');
 

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -59,7 +59,13 @@ class InitCommand extends Command
             $output->writeln('<error>Unable to resolve console path</error>');
             return Command::FAILURE;
         }
-        $command = '*/' . $frequency . ' * * * * ' . $path . ' aggregate';
+        $phpBinary = PHP_BINARY !== '' ? PHP_BINARY : 'php';
+        $command = sprintf(
+            '*/%d * * * * %s %s aggregate --no-interaction',
+            $frequency,
+            escapeshellarg($phpBinary),
+            escapeshellarg($path)
+        );
 
         if (strpos($crontabString, $command) === false) {
             $crontabString .= "\n" . $command . "\n";

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -59,7 +59,7 @@ class InitCommand extends Command
             $output->writeln('<error>Unable to resolve console path</error>');
             return Command::FAILURE;
         }
-        $phpBinary = PHP_BINARY !== '' ? PHP_BINARY : 'php';
+        $phpBinary = PHP_BINARY;
         $command = sprintf(
             '*/%d * * * * %s %s aggregate --no-interaction',
             $frequency,

--- a/templates/lock_notification.html.twig
+++ b/templates/lock_notification.html.twig
@@ -1,7 +1,7 @@
 <html>
     <body>
-        <h1>Pinboard found .lock file</h1>
-        <p>Intaro Pinboard can't run data aggregating. The another instance of this script is already executing or broke.</p>
+        <h1>Pinboard could not acquire the aggregation lock</h1>
+        <p>Intaro Pinboard can't run data aggregation because another instance of the aggregation command is already executing.</p>
 
         {% include '_mail_footer.html.twig' %}
     </body>


### PR DESCRIPTION
## What changed

- replaced stale lock-file TTL handling with file locking via flock in aggregate
- guaranteed lock release in finally so failed aggregate runs no longer block later runs
- made register-crontab emit an explicit PHP binary invocation with --no-interaction
- updated the lock notification wording and deployment docs

## Why

Aggregate could leave var/aggregate.lock behind after any unhandled failure. That caused later cron runs to report a false concurrent execution state until the TTL expired.

## Impact

- aggregate no longer gets stuck behind stale lock files after runtime failures
- cron examples and generated crontab entries now pin the intended PHP binary

## Validation

- php -l src/Command/AggregateCommand.php
- php -l src/Command/InitCommand.php
- php bin/console lint:twig templates/lock_notification.html.twig
- php bin/console doctrine:migrations:migrate --no-interaction
- php bin/console aggregate --no-interaction
