### PR TITLE
fix(docker): bump nginx apk pin to 1.28.3-r4

### DIFF
--- a/Dockerfile.pinboard
+++ b/Dockerfile.pinboard
@@ -64,7 +64,7 @@ RUN apk add --no-cache \
     bash=5.3.3-r1 \
     curl=8.19.0-r0 \
     icu-dev=76.1-r1 \
-    nginx=1.28.3-r2 \
+    nginx=1.28.3-r4 \
     oniguruma-dev=6.9.10-r0 \
     supervisor=4.3.0-r0 \
     tzdata=2026b-r0 \


### PR DESCRIPTION
## Problem
The v2.1.6 release's Docker publish [failed](https://github.com/intaro/pinboard/actions/runs/28601631678): the runtime stage's `apk add` pinned `nginx=1.28.3-r2`, but Alpine has since superseded it with `1.28.3-r4` and drops old revisions from the repo, so the exact pin errored with `unable to select packages: nginx-1.28.3-r4 breaks: world[nginx=1.28.3-r2]`.

This is pre-existing pin rot, unrelated to the security dependency updates in #169 — it just surfaced on the release that followed.

## Fix
Bump the pin to the currently-available `nginx=1.28.3-r4`. All other apk pins still resolve against the digest-pinned `php:8.5-fpm-alpine` base (verified via `apk list -a`).

## Verification
Full local image build (`docker build -f Dockerfile.pinboard`) completes successfully — frontend (pnpm/Dart-sass), composer, and runtime stages all green.

> Note: exact `-rN` apk pins will rot again on the next Alpine security revision. A follow-up could switch to fuzzy revision matching (e.g. `nginx=~1.28.3`) to keep the upstream version pinned while tolerating revision bumps — left out here to keep this change minimal.