### PR TITLE
docs: point extension/engine links to maintained forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A web admin panel for **Pinba** — a MySQL storage engine that collects real-time performance statistics from PHP applications.
 
-Pinba was originally developed by [@tony2001](https://github.com/tony2001/pinba_engine) for MySQL ≤ 5.6 and is no longer maintained. This project ships with the [@XOlegator/pinba_engine](https://github.com/XOlegator/pinba_engine) fork, which adds MySQL 8.0 and 8.4 support. Pinboard itself is agnostic to which engine build you use.
+Pinba was originally developed by [@tony2001](https://github.com/tony2001/pinba_engine) for MySQL ≤ 5.6 and is no longer maintained. This project ships with the [@XOlegator/pinba_engine](https://github.com/XOlegator/pinba_engine) fork, which adds support for MySQL 8.0 / 8.4 LTS and MariaDB 10.11 / 11.8 LTS. Pinboard itself is agnostic to which engine build you use.
 
 ![Pinboard screenshots](docs/images/screenshot.png)
 
@@ -11,7 +11,7 @@ Pinba was originally developed by [@tony2001](https://github.com/tony2001/pinba_
 **Pinba** is a system for passive performance monitoring of PHP sites:
 
 1. **PHP extension** (`pinba`) — embedded in each PHP process, collects request timing, memory usage, CPU time, and custom timer groups. Sends a UDP packet to a Pinba server at the end of every request.
-2. **Pinba MySQL engine** (`pinba_engine`) — a MySQL plugin that receives those UDP packets and stores them as virtual tables. Acts as the "server" that listens on UDP port 30002.
+2. **Pinba engine** (`pinba_engine`) — a MySQL/MariaDB storage-engine plugin that receives those UDP packets and stores them as virtual tables. Acts as the "server" that listens on UDP port 30002.
 3. **Pinboard** (this project) — a Symfony web app that reads data from the Pinba MySQL engine, aggregates it on a 15-minute schedule, and displays dashboards with request-time histograms, memory usage graphs, error rates, and slow-request logs.
 
 ```
@@ -78,7 +78,7 @@ Restart PHP-FPM and make a few requests on your site.
 | `xolegator/pinba-engine:8.4-lts` | MySQL 8.4 LTS with Pinba storage engine plugin |
 | `xolegator/pinboard:latest` | Pinboard web UI + aggregate worker |
 
-The MySQL image bundles the [XOlegator/pinba_engine](https://github.com/XOlegator/pinba_engine) plugin — a fork of the original [tony2001/pinba_engine](https://github.com/tony2001/pinba_engine) with MySQL 8.0/8.4 support added.
+The database image bundles the [XOlegator/pinba_engine](https://github.com/XOlegator/pinba_engine) plugin — a fork of the original [tony2001/pinba_engine](https://github.com/tony2001/pinba_engine) with support for MySQL 8.0 / 8.4 LTS and MariaDB 10.11 / 11.8 LTS added from a single source tree.
 
 ## Developer setup (run on host)
 
@@ -160,8 +160,8 @@ Full variable reference: [docs/configuration.md](docs/configuration.md)
 
 ## Related projects
 
-- **[XOlegator/pinba_engine](https://github.com/XOlegator/pinba_engine)** — MySQL 8.0/8.4 port of the Pinba storage engine (fork of the original [tony2001/pinba_engine](https://github.com/tony2001/pinba_engine), which supported MySQL ≤ 5.6 and is no longer maintained).
-- **[PHP Pinba extension](https://github.com/tony2001/pinba_extension)** — the PHP extension that sends UDP packets. Available for PHP 7/8 via PECL or package managers.
+- **[XOlegator/pinba_engine](https://github.com/XOlegator/pinba_engine)** — actively maintained port of the Pinba storage engine with support for MySQL 8.0 / 8.4 LTS and MariaDB 10.11 / 11.8 LTS from a single source tree. A fork of the original [tony2001/pinba_engine](https://github.com/tony2001/pinba_engine), which supported MySQL ≤ 5.6 and is no longer maintained (kept here for reference as the original project).
+- **[XOlegator/pinba_extension](https://github.com/XOlegator/pinba_extension)** — actively maintained PHP extension that sends the UDP packets, supporting modern PHP 8.2–8.5. A fork of the original [tony2001/pinba_extension](https://github.com/tony2001/pinba_extension), which targeted older PHP versions and is no longer maintained (kept here for reference as the original project).
 
 ## Documentation
 


### PR DESCRIPTION
Actualizes the README's references to the upstream Pinba components.

## Changes
- **PHP extension** — "Related projects" now links to the actively maintained [XOlegator/pinba_extension](https://github.com/XOlegator/pinba_extension) (modern PHP 8.2–8.5). The original [tony2001/pinba_extension](https://github.com/tony2001/pinba_extension) is kept for reference as the original, no-longer-maintained project that targeted older PHP versions.
- **Pinba engine** — clarifies that [XOlegator/pinba_engine](https://github.com/XOlegator/pinba_engine) supports **MariaDB 10.11 / 11.8 LTS** alongside **MySQL 8.0 / 8.4 LTS** (intro paragraph, Docker-images note, Related projects), and describes `pinba_engine` as a MySQL/MariaDB storage engine.

Docs-only change (no release triggered). Version facts sourced from the current READMEs of the two forks.