### PR TITLE
chore(security): add Dependabot version updates and security policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+updates:
+  # Keep GitHub Actions current. CI pins actions to mutable major tags (@v6,
+  # @v5, ...), so weekly PRs surface upstream releases and security fixes for
+  # the third-party actions the pipeline depends on.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # PHP dependencies (Symfony/Twig/Doctrine). Security fixes are handled
+  # separately by Dependabot security updates; these proactive version PRs are
+  # grouped weekly and use a `chore` prefix so they don't trigger a release on
+  # their own (Release Please only bumps on feat/fix).
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+    labels:
+      - dependencies
+      - composer
+    groups:
+      symfony:
+        patterns:
+          - "symfony/*"
+      php-deps:
+        patterns:
+          - "*"
+
+  # Frontend build toolchain (Webpack Encore, Babel, Sass). Reads
+  # package.json + pnpm-lock.yaml.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      npm:
+        patterns:
+          - "*"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported Branch
+
+Security fixes are developed on the active `master` branch and shipped as tagged
+releases (`vX.Y.Z`) via the Release Please pipeline.
+
+## Supported Runtime Matrix
+
+Pinboard tracks currently supported PHP branches, matching `composer.json`
+(`php: >=8.4`) and the CI test matrix. As of 2026-07-02, the active matrix is:
+
+- `PHP 8.4`
+- `PHP 8.5`
+
+Older end-of-life PHP branches are not supported for security maintenance.
+
+Pinboard reads data from a Pinba storage engine
+([XOlegator/pinba_engine](https://github.com/XOlegator/pinba_engine)); vulnerabilities
+in the engine or in the [Pinba PHP extension](https://github.com/XOlegator/pinba_extension)
+should be reported to those projects.
+
+## Reporting A Vulnerability
+
+Please do not open a public issue for a suspected security vulnerability.
+
+Report it privately via GitHub's
+[private vulnerability reporting](https://github.com/intaro/pinboard/security/advisories/new),
+or by email to:
+
+- Oleg Ekhlakov <o.ekhlakov@protonmail.com>
+
+Include, when possible:
+
+- affected Pinboard version or commit;
+- affected PHP version;
+- reproduction steps;
+- whether the issue impacts confidentiality, integrity, availability, or data correctness;
+- whether the issue is authenticated-only or reachable pre-authentication.
+
+## Response Policy
+
+- Acknowledgement target: reasonable best effort.
+- Fixes should preserve the existing public contract unless a breaking security
+  mitigation is unavoidable.
+- Public release notes are published after a fix is prepared or released.


### PR DESCRIPTION
Part of a cross-repo security-posture pass. Repo-level toggles (Dependabot alerts + security updates, secret scanning + push protection, private vulnerability reporting, CodeQL default setup for Actions + JS) were enabled via the API; this PR adds the file-based config.

## Changes
- **`.github/dependabot.yml`** — weekly, grouped version-update PRs:
  - `github-actions` (prefix `ci`) — CI pins mutable major tags; surfaces upstream action releases/fixes.
  - `composer` (prefix `chore`, grouped `symfony/*` + rest) — proactive PHP dependency freshness.
  - `npm` (prefix `chore`) — Webpack Encore / Babel / Sass toolchain (reads package.json + pnpm-lock.yaml).
  - `chore`/`ci` prefixes keep routine bumps from triggering a release; **security** updates are handled automatically by the repo-level Dependabot security-updates setting.
- **`SECURITY.md`** — private vulnerability reporting policy and supported PHP matrix (8.4 / 8.5), mirroring the convention in the sibling `pinba_extension` repo.