### PR TITLE
chore(release): scope releases to shipped changes (version discipline)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ All changes enter `master` exclusively via pull request — direct pushes are bl
 - Merging the Release PR creates a `vX.Y.Z` tag and GitHub Release.
 - The Docker workflow fires on the published release and pushes `xolegator/pinboard:<version>` and `xolegator/pinboard:latest` to Docker Hub.
 
+**Version discipline — choose the commit type by what the change affects, so the version only moves for real app changes.** Application code and the shipped runtime image (`src/**`, `templates/**`, `assets/**`, `migrations/**`, `config/**`, `public/**`, `bin/**`, runtime deps in `composer.json`/`composer.lock` and `package.json`/`pnpm-lock.yaml`, and `Dockerfile.pinboard`) use `feat:`/`fix:` and cut a new version, tag, and Docker image. CI and automation (`.github/**`), docs (`docs/**`, `*.md`), tests and QA config (`tests/**`, `phpstan.neon`, `.php-cs-fixer.dist.php`), and dev-only tooling (`Makefile`, dev-stack `docker/`) use `ci:`/`build:`/`chore:`/`docs:`/`test:`/`style:`/`refactor:` and do **not** trigger a release. Prefer `fix` over `feat` for behaviour corrections. Only `feat`, `fix`, `perf`, `revert`, `deps` and breaking changes are release-triggering. See `docs/releasing.md` → "Version discipline: what warrants a release" for the full rule and reasoning.
+
 Full details: `docs/contributing.md` (PR workflow) and `docs/releasing.md` (release process).
 
 ## Commit Messages

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,20 +31,30 @@ This project follows [Conventional Commits](https://www.conventionalcommits.org/
 type(scope): short imperative description
 ```
 
-Common types and their effect on versioning:
+Common types and their effect on versioning. Only user-facing types trigger a release; the rest are
+folded into the next release's changelog but do **not** cut a version or Docker image on their own:
 
-| Type       | SemVer bump | Appears in changelog |
-|------------|-------------|----------------------|
-| `feat`     | minor       | yes                  |
-| `fix`      | patch       | yes                  |
-| `perf`     | patch       | yes                  |
-| `refactor` | patch       | yes                  |
-| `chore`    | patch       | yes                  |
-| `docs`     | patch       | hidden               |
-| `test`     | patch       | hidden               |
-| `ci`       | patch       | hidden               |
+| Type       | SemVer bump      | Triggers release? | Appears in changelog |
+|------------|------------------|-------------------|----------------------|
+| `feat`     | minor            | yes               | yes                  |
+| `fix`      | patch            | yes               | yes                  |
+| `perf`     | patch            | yes               | yes                  |
+| `deps`     | patch            | yes               | yes                  |
+| `revert`   | patch            | yes               | yes                  |
+| `refactor` | none             | **no**            | hidden               |
+| `chore`    | none             | **no**            | hidden               |
+| `docs`     | none             | **no**            | hidden               |
+| `test`     | none             | **no**            | hidden               |
+| `build`    | none             | **no**            | hidden               |
+| `style`    | none             | **no**            | hidden               |
+| `ci`       | none             | **no**            | hidden               |
 
 A `!` suffix or `BREAKING CHANGE:` footer triggers a **major** bump regardless of type.
+
+Pick the type by *what the change affects*, not how big it feels — see
+[docs/releasing.md → "Version discipline"](releasing.md) for the full rule. In short: application
+code and the shipped Docker image use `feat`/`fix`; CI, docs, tests and tooling use
+`ci`/`docs`/`test`/`chore` and do not cut a release.
 
 Useful scopes for this project: `ui`, `auth`, `api`, `db`, `config`, `docker`, `ci`, `docs`.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,11 +13,70 @@ Releases are fully automated via [Release Please](https://github.com/googleapis/
 
 ## Version bump rules
 
-Release Please derives the next version from Conventional Commits:
+Release Please derives the next version from Conventional Commits. Only **user-facing** commit
+types trigger a release:
 
-- `BREAKING CHANGE` footer or `!` suffix → major bump
-- `feat` → minor bump
-- anything else (`fix`, `perf`, `refactor`, `chore`, …) → patch bump
+- `BREAKING CHANGE` footer or `!` suffix → **major** bump
+- `feat` → **minor** bump
+- `fix`, `perf`, `revert`, `deps` → **patch** bump
+
+### Commits that do not trigger a release
+
+These types are **not** release-triggering on their own and will not open a Release PR by
+themselves:
+
+- `docs`, `style`, `refactor`, `test`, `build`, `ci`, `chore`.
+
+In particular, a documentation-only, CI-only, or tooling-only change does **not** produce a new
+release (and therefore no new Docker image). Such commits are still valid — they are simply folded
+into the changelog of the next release that *is* triggered by a release-triggering commit. They do
+not start a release on their own.
+
+> This is the default Release Please behaviour and matches the sibling
+> [pinba_engine](https://github.com/XOlegator/pinba_engine) and
+> [pinba_extension](https://github.com/XOlegator/pinba_extension) repositories. `release-please-config.json`
+> intentionally keeps no custom `changelog-sections`, so `chore`/`refactor` do not inflate the version.
+
+## Version discipline: what warrants a release
+
+The version — the `vX.Y.Z` tag and the published `xolegator/pinboard:<version>` Docker image —
+tracks the **shipped application** only. Pick a commit type by *what the change actually affects*,
+not by how big it feels:
+
+- **Application code and the runtime image** — anything that changes the deployed Pinboard app or
+  the image users pull: `src/**`, `templates/**`, `assets/**`, `migrations/**`, `config/**`,
+  `public/**`, `bin/**`, runtime dependencies (`composer.json` / `composer.lock`, `package.json` /
+  `pnpm-lock.yaml`), and the shipped image definition (`Dockerfile.pinboard` and the runtime pieces
+  under `docker/` that change the published image — e.g. an nginx/php-fpm apk pin bump). Use
+  `feat:` (a new capability → `minor`) or `fix:` (a bug or behaviour correction → `patch`, this
+  includes security-relevant dependency fixes). These cut a new version, tag, and Docker image.
+- **Everything else** — CI and automation (`.github/**`: `ci.yml`, `docker.yml`,
+  `release-please.yml`, `dependabot.yml`), documentation (`docs/**`, `README.md`, `*.md`,
+  `CHANGELOG*`), tests and QA config (`tests/**`, `phpunit.xml.dist`, `phpstan.neon`,
+  `.php-cs-fixer.dist.php`, `.pre-commit-config.yaml`) and dev-only tooling (`Makefile`, the dev
+  stack under `docker/`). Use `ci:`, `build:`, `chore:`, `docs:`, `test:`, `style:` or `refactor:`.
+  These do **not** bump the version: the shipped image is identical, so there is no reason to
+  publish a new release or rebuild an identical Docker image.
+
+Why it matters: every release fires the `docker.yml` workflow and pushes a new
+`xolegator/pinboard:<version>` + `:latest`. A new tag for a docs or CI tweak forces an identical
+image rebuild and churns the changelog for no user benefit. Packaging or CI churn must never inflate
+the application's version.
+
+Two rules of thumb:
+
+- **Prefer `fix` over `feat` for corrections.** `feat` is for new capability only; making
+  previously surprising or incorrect behaviour correct is a `fix` (a `patch`).
+- **Routine dependency bumps ride the next real release.** Dependabot's default `chore(deps): ...`
+  does not cut a release; re-type it as `fix(deps): ...` only when the update is a fix that must
+  ship on its own (e.g. a security advisory, as in 2.1.6).
+
+Examples:
+
+- Bump an nginx apk pin in `Dockerfile.pinboard` → `fix(docker): ...` (`patch`, new image — as in 2.1.7).
+- Make the error-code threshold configurable → `feat(aggregate): ...` (`minor`).
+- Add status badges or reword the README → `docs(readme): ...` (no release).
+- Bump a GitHub Action version → `ci: ...` (no release).
 
 ## Docker image publishing
 
@@ -46,7 +105,10 @@ Add these under **Settings → Secrets and variables → Actions** in the GitHub
 
 - `release-type: simple` — manages `CHANGELOG.md` and git tags; does not modify `composer.json`.
 - `changelog-path: CHANGELOG.md` — separate from the hand-maintained `CHANGELOG` file which covers the pre-2.x history.
-- Changelog sections and which commit types are shown or hidden.
+- No custom `changelog-sections` — the config relies on Release Please defaults so that only
+  user-facing types (`feat`, `fix`, `perf`, `revert`, `deps`, breaking) trigger a release and appear
+  in the changelog, while `docs`/`ci`/`chore`/`refactor`/`test`/`build`/`style` are hidden and
+  non-triggering. See "Version bump rules" above.
 
 ## Branch protection requirements
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,16 +6,5 @@
       "changelog-path": "CHANGELOG.md",
       "component": ""
     }
-  },
-  "bump-patch-for-minor-pre-major": false,
-  "changelog-sections": [
-    {"type": "feat",     "section": "Features"},
-    {"type": "fix",      "section": "Bug Fixes"},
-    {"type": "perf",     "section": "Performance"},
-    {"type": "refactor", "section": "Refactoring"},
-    {"type": "chore",    "section": "Maintenance"},
-    {"type": "docs",     "section": "Documentation", "hidden": true},
-    {"type": "test",     "section": "Tests",         "hidden": true},
-    {"type": "ci",       "hidden": true}
-  ]
+  }
 }


### PR DESCRIPTION
## What & why

Pinboard's `release-please-config.json` carried a custom `changelog-sections` block that made `chore` and `refactor` **release-triggering**. As a result, non-code changes cut releases and rebuilt an identical Docker image — e.g. the currently-open **release PR #175 ("release 2.1.8")** was triggered purely by a `docs:` (#173) + `chore(security):` (#174) commit, with no application change.

This restores parity with the sibling **pinba_engine** and **pinba_extension** repos, which use Release Please defaults.

## Changes

- **`release-please-config.json`** — drop custom `changelog-sections` (and the no-op `bump-patch-for-minor-pre-major`). Now only `feat`, `fix`, `perf`, `revert`, `deps` and breaking changes trigger a release. `docs`/`ci`/`chore`/`refactor`/`test`/`build`/`style` do **not**.
- **`docs/releasing.md`** — corrected bump rules + new **"Version discipline: what warrants a release"** section (mirrors the sibling repos).
- **`docs/contributing.md`** — fixed the version table (previously claimed every type → patch).
- **`AGENTS.md`** — added a version-discipline note.

## Effect on the open 2.1.8 release PR

Once this lands, the next Release Please run reads the new config and should **auto-close release PR #175**, since the only unreleased commits (docs + chore) are no longer release-triggering.

This PR itself is `chore(release):` and does not cut a release.