### PR TITLE
ci: collect and upload PHPUnit coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,36 @@ jobs:
           APP_ENV: test
           DATABASE_URL: mysql://pinba:pinba@127.0.0.1:3306/pinba?serverVersion=8.4.0
         run: vendor/bin/phpunit --no-progress
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: intl, pdo_mysql
+          coverage: pcov
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.composer/cache
+          key: composer-8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-8.4-
+
+      - run: composer install --no-interaction --prefer-dist --no-scripts
+
+      - name: Run test suite with coverage
+        env:
+          APP_ENV: test
+          DATABASE_URL: mysql://pinba:pinba@127.0.0.1:3306/pinba?serverVersion=8.4.0
+        run: vendor/bin/phpunit --no-progress --coverage-clover coverage.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pinboard
 
 [![CI](https://github.com/intaro/pinboard/actions/workflows/ci.yml/badge.svg)](https://github.com/intaro/pinboard/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/intaro/pinboard/branch/master/graph/badge.svg)](https://codecov.io/gh/intaro/pinboard)
 [![Release](https://img.shields.io/github/v/release/intaro/pinboard)](https://github.com/intaro/pinboard/releases/latest)
 [![Docker Pulls](https://img.shields.io/docker/pulls/xolegator/pinboard?logo=docker&logoColor=white)](https://hub.docker.com/r/xolegator/pinboard)
 [![Docker Image Size](https://img.shields.io/docker/image-size/xolegator/pinboard/latest?logo=docker&logoColor=white)](https://hub.docker.com/r/xolegator/pinboard)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+# Codecov configuration for Pinboard.
+#
+# Coverage is collected by the `coverage` job in .github/workflows/ci.yml, which
+# runs the PHPUnit suite with pcov and uploads a Clover report. Only `src/**` is
+# measured (see the <source> block in phpunit.xml.dist).
+
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 1
+  round: down
+  # Report coverage as a signal, but never block a PR on it. The suite is a mix
+  # of unit tests and a functional kernel-wiring smoke test; a hard coverage gate
+  # would be misleading at this stage.
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: false
+
+ignore:
+  - "src/Kernel.php"   # Symfony framework glue, no meaningful branches to test


### PR DESCRIPTION
Adds code-coverage collection to CI and a Codecov badge, matching the sibling **pinba_engine** and **pinba_extension** repositories.

## Changes
- **`.github/workflows/ci.yml`** — new `coverage` job: runs PHPUnit under **pcov** and uploads a Clover report via `codecov/codecov-action@v5` (`fail_ci_if_error: false`).
- **`codecov.yml`** — project config: informational (non-blocking) project/patch status, sensible defaults, ignores `src/Kernel.php`.
- **`README.md`** — Codecov badge next to CI.

## ⚠️ One manual step required for the badge to populate
The upload references `secrets.CODECOV_TOKEN`, which is **not yet set** on this repo (current secrets: `DOCKERHUB_*`, `RELEASE_PLEASE_TOKEN`). To activate:
1. Add the repo on [codecov.io](https://codecov.io) (GitHub login).
2. Copy its upload token → **Settings → Secrets and variables → Actions → `CODECOV_TOKEN`**.

Until then CI stays green (upload is best-effort) but the badge shows "unknown".

`ci:` change — does not trigger a release.