### PR TITLE
ci: add advanced CodeQL workflow and badge

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,17 @@
+name: Pinboard CodeQL config
+
+# Only hand-written frontend source under assets/ is our own JavaScript. The rest
+# is either third-party (node_modules, PHP vendor) or generated build output that
+# ships to the browser but is not our source of truth — analysing it just produces
+# noise, so exclude it from the javascript-typescript analysis.
+paths-ignore:
+  - "node_modules/**"
+  - "vendor/**"
+  - "public/build/**"
+  - "public/bundles/**"
+
+# security-extended is the deeper security-focused suite (taint tracking) without
+# the maintainability/style queries of security-and-quality — matches the query
+# suite the previous default setup used and the sibling pinba_engine config.
+queries:
+  - uses: security-extended

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly, offset from the other Monday crons in the ecosystem repos.
+    - cron: "47 5 * * 1"
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Pinboard's application code is PHP, which CodeQL does not support.
+        # The languages CodeQL can analyse here are the GitHub Actions workflows
+        # and the frontend JavaScript/TypeScript under assets/. Both are
+        # interpreted, so no build step is needed (build-mode: none).
+        language: [actions, javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pinboard
 
 [![CI](https://github.com/intaro/pinboard/actions/workflows/ci.yml/badge.svg)](https://github.com/intaro/pinboard/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/intaro/pinboard/actions/workflows/codeql.yml/badge.svg)](https://github.com/intaro/pinboard/actions/workflows/codeql.yml)
 [![codecov](https://codecov.io/gh/intaro/pinboard/branch/master/graph/badge.svg)](https://codecov.io/gh/intaro/pinboard)
 [![Release](https://img.shields.io/github/v/release/intaro/pinboard)](https://github.com/intaro/pinboard/releases/latest)
 [![Docker Pulls](https://img.shields.io/docker/pulls/xolegator/pinboard?logo=docker&logoColor=white)](https://hub.docker.com/r/xolegator/pinboard)


### PR DESCRIPTION
Replaces the repo-level **CodeQL default setup** with a committed workflow (config-as-code), matching the sibling **pinba_engine** and **pinba_extension** repos, and adds a CodeQL badge.

## Changes
- **`.github/workflows/codeql.yml`** — analyses `actions` + `javascript-typescript` (build-mode: none), `security-extended` suite, weekly cron. PHP is not a CodeQL-supported language, so it is not analysed (same coverage the default setup provided).
- **`.github/codeql/codeql-config.yml`** — `security-extended` queries + `paths-ignore` for `node_modules`, `vendor`, and compiled `public/build`.
- **`README.md`** — CodeQL badge next to CI.

## Setup note
The repo's CodeQL **default setup has been disabled** (via API) so this advanced config can run without conflict — the two modes are mutually exclusive. Scanning coverage is unchanged (actions + JS/TS).

`ci:` change — does not trigger a release.