### PR TITLE
ci: bump codeql checkout to v7 and pin action-version policy

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
         language: [actions, javascript-typescript]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,23 @@ All changes enter `master` exclusively via pull request — direct pushes are bl
 
 Full details: `docs/contributing.md` (PR workflow) and `docs/releasing.md` (release process).
 
+## GitHub Actions
+
+- When adding or editing a workflow, pin every third-party action to its current
+  major version. Always verify the latest release before committing instead of
+  reusing a version from memory or copying an old example, e.g.:
+
+  ```bash
+  gh api repos/actions/checkout/releases/latest --jq .tag_name
+  ```
+
+- Reference actions by their major tag (e.g. `actions/checkout@v7`) so they track
+  the latest compatible patch, and never introduce a version older than what the
+  rest of the repository (or the sibling Pinba repositories) already uses.
+- Dependabot (`.github/dependabot.yml`) opens grouped `ci:` PRs for action bumps;
+  keep all workflows (`ci.yml`, `codeql.yml`, `docker.yml`, `release-please.yml`)
+  on the same current majors.
+
 ## Commit Messages
 
 - Use Conventional Commits style.


### PR DESCRIPTION
Follow-up to the Dependabot github-actions bump (#181), which brought `ci.yml` and `docker.yml` to the current majors (`checkout@v7`, `cache@v6`, `codecov-action@v7`) but did not touch `codeql.yml` (added afterwards).

## Changes
- **`.github/workflows/codeql.yml`** — `actions/checkout@v6 → @v7`, matching every other workflow.
- **`AGENTS.md`** — new **GitHub Actions** section pinning the policy: keep every third-party action on its current major, verified against the latest release before committing (mirrors the sibling `pinba_engine`/`pinba_extension` AGENTS.md).

## Version audit result — all workflows now on latest majors
| Action | Version | Latest |
|---|---|---|
| actions/checkout | v7 | v7 ✅ |
| actions/cache | v6 | v6 ✅ |
| codecov/codecov-action | v7 | v7 ✅ |
| shivammathur/setup-php | v2 | v2 ✅ |
| github/codeql-action | v4 | v4 ✅ |
| docker/setup-buildx-action | v4 | v4 ✅ |
| docker/login-action | v4 | v4 ✅ |
| docker/build-push-action | v7 | v7 ✅ |
| googleapis/release-please-action | v5 | v5 ✅ |

`ci:` change — does not trigger a release.