### PR TITLE
test: cover legacy password hashing and aggregate config parsing

### DIFF
--- a/tests/Unit/Command/AggregateCommandConfigTest.php
+++ b/tests/Unit/Command/AggregateCommandConfigTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\AggregateCommand;
+use App\Command\AggregateConfig;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Twig\Environment;
+
+/**
+ * Covers the environment/config-parsing layer of the aggregate command. These are
+ * the knobs that decide data retention, per-server slow/heavy thresholds, and who
+ * gets alerted — a silent parsing bug here misconfigures monitoring without any
+ * error surfacing, so the exact contracts are pinned here.
+ *
+ * The parsing methods are private but pure (no DB/mail side effects), so they are
+ * exercised directly with reflection over an instance built from mocked collaborators.
+ */
+final class AggregateCommandConfigTest extends TestCase
+{
+    /** @var list<string> env keys set during a test, cleared in tearDown */
+    private array $touchedEnv = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->touchedEnv as $name) {
+            unset($_ENV[$name], $_SERVER[$name]);
+        }
+        $this->touchedEnv = [];
+    }
+
+    private function setEnv(string $name, string $value): void
+    {
+        $_ENV[$name] = $value;
+        $this->touchedEnv[] = $name;
+    }
+
+    private function command(): AggregateCommand
+    {
+        // Passive collaborators — the parsing methods under test never touch them,
+        // so plain stubs (no expectations) are the right tool.
+        $kernel = $this->createStub(KernelInterface::class);
+        $kernel->method('getProjectDir')->willReturn(sys_get_temp_dir());
+
+        return new AggregateCommand(
+            $this->createStub(Connection::class),
+            $this->createStub(Environment::class),
+            $this->createStub(MailerInterface::class),
+            $kernel,
+        );
+    }
+
+    private function invoke(AggregateCommand $command, string $method, mixed ...$args): mixed
+    {
+        $ref = new \ReflectionMethod($command, $method);
+        $ref->setAccessible(true);
+
+        return $ref->invoke($command, ...$args);
+    }
+
+    // ---- envBool: only 1/true/yes/on (case-insensitive) are true --------------
+
+    public function testEnvBoolAcceptsCanonicalTruthyValues(): void
+    {
+        $command = $this->command();
+
+        foreach (['1', 'true', 'TRUE', 'yes', 'On', 'ON'] as $raw) {
+            $this->setEnv('TEST_BOOL', $raw);
+            self::assertTrue($this->invoke($command, 'envBool', 'TEST_BOOL', false), "'$raw' should be true");
+        }
+    }
+
+    public function testEnvBoolRejectsEverythingElseEvenOverridingATrueDefault(): void
+    {
+        $command = $this->command();
+
+        // A set-but-non-truthy value must win over a true default (e.g. explicitly
+        // disabling notifications with APP_NOTIFICATION_ENABLE=0).
+        foreach (['0', 'false', 'no', 'off', '2', 'enabled'] as $raw) {
+            $this->setEnv('TEST_BOOL', $raw);
+            self::assertFalse($this->invoke($command, 'envBool', 'TEST_BOOL', true), "'$raw' should be false");
+        }
+    }
+
+    public function testEnvBoolFallsBackToDefaultWhenUnset(): void
+    {
+        $command = $this->command();
+
+        self::assertTrue($this->invoke($command, 'envBool', 'TEST_BOOL_UNSET', true));
+        self::assertFalse($this->invoke($command, 'envBool', 'TEST_BOOL_UNSET', false));
+    }
+
+    // ---- envInt: positive integers only, otherwise the default ----------------
+
+    public function testEnvIntAcceptsPositiveIntegers(): void
+    {
+        $command = $this->command();
+        $this->setEnv('TEST_INT', '750');
+
+        self::assertSame(750, $this->invoke($command, 'envInt', 'TEST_INT', 500));
+    }
+
+    public function testEnvIntRejectsZeroNegativeAndNonNumeric(): void
+    {
+        $command = $this->command();
+
+        // Zero and negatives are treated as "not a valid threshold" and fall back to
+        // the default — pinning this avoids a surprising APP_MIN_ERROR_CODE=0 silently
+        // becoming 500.
+        foreach (['0', '-5', 'abc', '5xx'] as $raw) {
+            $this->setEnv('TEST_INT', $raw);
+            self::assertSame(500, $this->invoke($command, 'envInt', 'TEST_INT', 500), "'$raw' should fall back");
+        }
+
+        self::assertSame(500, $this->invoke($command, 'envInt', 'TEST_INT_UNSET', 500));
+    }
+
+    // ---- envCsv: trimmed, empty segments dropped ------------------------------
+
+    public function testEnvCsvTrimsAndDropsEmptySegments(): void
+    {
+        $command = $this->command();
+        $this->setEnv('TEST_CSV', 'a, b ,,c,');
+
+        self::assertSame(['a', 'b', 'c'], $this->invoke($command, 'envCsv', 'TEST_CSV'));
+    }
+
+    public function testEnvCsvReturnsEmptyListWhenUnset(): void
+    {
+        $command = $this->command();
+
+        self::assertSame([], $this->invoke($command, 'envCsv', 'TEST_CSV_UNSET'));
+    }
+
+    // ---- envJson: invalid JSON degrades to the default ------------------------
+
+    public function testEnvJsonReturnsDefaultOnInvalidJson(): void
+    {
+        $command = $this->command();
+        $this->setEnv('TEST_JSON', '{not valid json');
+
+        self::assertSame(['fallback'], $this->invoke($command, 'envJson', 'TEST_JSON', ['fallback']));
+    }
+
+    // ---- buildFloatMap: global + numeric per-server overrides -----------------
+
+    public function testBuildFloatMapUsesGlobalDefaultWhenUnset(): void
+    {
+        $command = $this->command();
+
+        self::assertSame(
+            ['global' => 1.5],
+            $this->invoke($command, 'buildFloatMap', 'TEST_FM_GLOBAL_UNSET', '1.5', 'TEST_FM_MAP_UNSET'),
+        );
+    }
+
+    public function testBuildFloatMapMergesNumericOverridesAndSkipsInvalid(): void
+    {
+        $command = $this->command();
+        $this->setEnv('TEST_FM_GLOBAL', '2.5');
+        // srv1 int and srv2 numeric-string are kept and coerced to float; the
+        // non-numeric "bad" entry is dropped rather than poisoning the map.
+        $this->setEnv('TEST_FM_MAP', '{"srv1":3,"srv2":"4.5","bad":"x"}');
+
+        self::assertSame(
+            ['global' => 2.5, 'srv1' => 3.0, 'srv2' => 4.5],
+            $this->invoke($command, 'buildFloatMap', 'TEST_FM_GLOBAL', '1.5', 'TEST_FM_MAP'),
+        );
+    }
+
+    // ---- buildNotificationList: only well-formed {hosts,email} rows survive ----
+
+    public function testBuildNotificationListKeepsOnlyCompleteStringRows(): void
+    {
+        $command = $this->command();
+        $this->setEnv(
+            'TEST_NL',
+            '[{"hosts":"a","email":"a@x"},{"hosts":"b"},{"email":"z@x"},"garbage",{"hosts":"c","email":"c@x"}]',
+        );
+
+        self::assertSame(
+            [
+                ['hosts' => 'a', 'email' => 'a@x'],
+                ['hosts' => 'c', 'email' => 'c@x'],
+            ],
+            $this->invoke($command, 'buildNotificationList', 'TEST_NL'),
+        );
+    }
+
+    public function testBuildNotificationListReturnsEmptyForNonArrayJson(): void
+    {
+        $command = $this->command();
+        $this->setEnv('TEST_NL', '"just a string"');
+
+        self::assertSame([], $this->invoke($command, 'buildNotificationList', 'TEST_NL'));
+    }
+
+    // ---- isNotIgnore: unanchored regex match against the ignore list ----------
+
+    public function testIsNotIgnoreMatchesIgnorePatternsAsUnanchoredRegex(): void
+    {
+        $command = $this->command();
+        $this->setConfigIgnore($command, ['^prod', 'staging']);
+
+        // Matched (i.e. ignored) → isNotIgnore returns false.
+        self::assertFalse($this->invoke($command, 'isNotIgnore', 'prod-web-1'), 'anchored ^prod matches');
+        self::assertFalse($this->invoke($command, 'isNotIgnore', 'staging-2'), 'staging matches at start');
+        self::assertFalse($this->invoke($command, 'isNotIgnore', 'my-staging-box'), 'unanchored: substring matches');
+
+        // Not matched → isNotIgnore returns true (host is alerted on).
+        self::assertTrue($this->invoke($command, 'isNotIgnore', 'app-live'));
+        self::assertTrue($this->invoke($command, 'isNotIgnore', 'web-production'), '^prod does not match mid-string');
+    }
+
+    public function testIsNotIgnoreReturnsTrueWhenIgnoreListEmpty(): void
+    {
+        $command = $this->command();
+        $this->setConfigIgnore($command, []);
+
+        self::assertTrue($this->invoke($command, 'isNotIgnore', 'anything'));
+    }
+
+    /** @param list<string> $ignore */
+    private function setConfigIgnore(AggregateCommand $command, array $ignore): void
+    {
+        $config = new AggregateConfig(
+            recordsLifetime: 'P1M',
+            aggregationPeriod: 'PT15M',
+            longRequestTime: ['global' => 1.5],
+            heavyRequest: ['global' => 30000.0],
+            heavyCpuRequest: ['global' => 1.0],
+            notificationEnable: true,
+            notificationSender: 'noreply@pinboard',
+            notificationGlobalEmail: 'ops@example.com',
+            notificationIgnore: $ignore,
+            notificationList: [],
+            reqTimeBorder: ['global' => 1.5],
+            minErrorCode: 500,
+        );
+
+        $ref = new \ReflectionProperty($command, 'config');
+        $ref->setAccessible(true);
+        $ref->setValue($command, $config);
+    }
+}

--- a/tests/Unit/Security/LegacyMessageDigestPasswordHasherTest.php
+++ b/tests/Unit/Security/LegacyMessageDigestPasswordHasherTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Security;
+
+use App\Security\LegacyMessageDigestPasswordHasher;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The legacy hasher must stay bit-for-bit compatible with the sha512/5000-iteration
+ * base64 scheme used by pre-2.x (Silex-era) Pinboard, otherwise every existing
+ * stored password stops verifying and users are silently locked out. These tests
+ * pin the wire format (known vectors) and the intentional saltless determinism so a
+ * well-meaning "improvement" (changing the iteration count, the concatenation order,
+ * or adding a salt) cannot land unnoticed.
+ */
+final class LegacyMessageDigestPasswordHasherTest extends TestCase
+{
+    // Canonical Symfony MessageDigestPasswordHasher output: sha512, 5000 iterations,
+    // empty salt, base64-encoded. Recomputing these requires the exact legacy recipe.
+    private const KNOWN_VECTORS = [
+        'pinboard' => 'dbKeJ2b0FONX7r6SpuxBoEezcRLmwf6WTLoPuWTcasv7gi9s/jcUOuxWCxhmn2qSbR+FLAf62PlnpWTtRuBNmw==',
+        's3cr3t' => 'nqQ1mA6Y/pt0XdIw/d1G7Hc4Ce9BEqmSSxMMLY3CkE3iP9OQq/nnLCZCQxntH6jMNqRTsJDSTwHW4+PlwTZLVA==',
+        '' => 'Vdbm7LMUbfL6Wm1WDrTLshjJD5r50nPo/ABPfoCRBAff6IdF0TP160zGRILuVYIHXyoDyhTV/BvquNQgEY2uew==',
+    ];
+
+    public function testHashMatchesKnownLegacyVectors(): void
+    {
+        $hasher = new LegacyMessageDigestPasswordHasher();
+
+        foreach (self::KNOWN_VECTORS as $plain => $expected) {
+            self::assertSame(
+                $expected,
+                $hasher->hash($plain),
+                sprintf('Legacy hash for %s must not change', var_export($plain, true))
+            );
+        }
+    }
+
+    public function testHashIsDeterministicAndSaltless(): void
+    {
+        $hasher = new LegacyMessageDigestPasswordHasher();
+
+        // Two independent hashes of the same password must be identical — the scheme
+        // has no random salt on purpose, which is what lets stored hashes be verified.
+        self::assertSame($hasher->hash('pinboard'), $hasher->hash('pinboard'));
+    }
+
+    public function testVerifyAcceptsCorrectPassword(): void
+    {
+        $hasher = new LegacyMessageDigestPasswordHasher();
+
+        self::assertTrue($hasher->verify(self::KNOWN_VECTORS['pinboard'], 'pinboard'));
+        self::assertTrue($hasher->verify(self::KNOWN_VECTORS['s3cr3t'], 's3cr3t'));
+    }
+
+    public function testVerifyRejectsWrongPassword(): void
+    {
+        $hasher = new LegacyMessageDigestPasswordHasher();
+
+        self::assertFalse($hasher->verify(self::KNOWN_VECTORS['pinboard'], 'Pinboard'));
+        self::assertFalse($hasher->verify(self::KNOWN_VECTORS['pinboard'], 'wrong'));
+        self::assertFalse($hasher->verify(self::KNOWN_VECTORS['pinboard'], ''));
+    }
+
+    public function testVerifyRejectsMalformedHashWithoutError(): void
+    {
+        $hasher = new LegacyMessageDigestPasswordHasher();
+
+        // A truncated / garbage stored hash must simply fail to verify (hash_equals
+        // handles the length mismatch), never throw.
+        self::assertFalse($hasher->verify('not-a-real-hash', 'pinboard'));
+        self::assertFalse($hasher->verify('', 'pinboard'));
+    }
+
+    public function testNeedsRehashIsAlwaysFalse(): void
+    {
+        $hasher = new LegacyMessageDigestPasswordHasher();
+
+        // Legacy hashes are frozen: rehashing would destroy compatibility, so the
+        // hasher must never ask the framework to rehash on login.
+        self::assertFalse($hasher->needsRehash(self::KNOWN_VECTORS['pinboard']));
+        self::assertFalse($hasher->needsRehash('anything'));
+    }
+}


### PR DESCRIPTION
Raises coverage on two areas where a **silent** regression is expensive and would not surface as any error — deliberately not chasing percentage on getters/entities/DB glue.

## What is covered and why it matters
- **`LegacyMessageDigestPasswordHasher`** (security) — pins the sha512 / 5000-iteration / base64 wire format via known vectors, plus the *intentional* saltless determinism and `needsRehash = false`. A well-meaning change to the recipe (iterations, concat order, adding a salt) would silently stop every pre-2.x stored password from verifying and lock users out. The vectors are the canonical Symfony legacy `MessageDigestPasswordHasher` values.
- **`AggregateCommand` config parsing** — the knobs that decide data retention, per-server slow/heavy thresholds, and alert routing. Pins the real contracts: truthy-only `envBool` (so `=0` disables), positive-int-only `envInt` (surprising `0 → default`), CSV trimming, numeric-only threshold overrides in `buildFloatMap`, well-formed-rows-only `buildNotificationList`, and the **unanchored** ignore-regex in `isNotIgnore`. The pure private parsers are exercised via reflection over stubbed collaborators (no DB/mail).

## Verification (local)
- PHPUnit: **52 tests, 111 assertions**, green (+20 new).
- PHPStan level 10: no errors. php-cs-fixer: clean.

No production code changed. `test:` — does not trigger a release.