### PR TITLE
ci: harden Actions workflows (least-privilege token + SHA-pinned actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   cs-fixer:
@@ -18,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.4'
           extensions: intl, pdo_mysql
@@ -40,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.4'
           extensions: intl, pdo_mysql
@@ -80,7 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: intl, pdo_mysql
@@ -106,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.4'
           extensions: intl, pdo_mysql
@@ -127,7 +130,7 @@ jobs:
         run: vendor/bin/phpunit --no-progress --coverage-clover coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-push:
     name: Build and push Docker image
@@ -19,9 +22,9 @@ jobs:
         with:
           ref: ${{ inputs.release-tag != '' && inputs.release-tag || github.ref }}
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -33,7 +36,7 @@ jobs:
           VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.pinboard

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: rp
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
Устраняет все открытые предупреждения из **code scanning** (`/security/code-scanning`).

## Что сделано

### `actions/missing-workflow-permissions` (5 алертов)
Добавлен top-level блок `permissions: contents: read` в `ci.yml` и `docker.yml`.
Ни одна из job'ов этих воркфлоу не пишет через `GITHUB_TOKEN` (Codecov и Docker Hub используют свои секреты), поэтому read-only токена достаточно и он становится least-privilege для всех job'ов. `codeql.yml` и `release-please.yml` уже имели явные `permissions`.

### `actions/unpinned-tag` (9 алертов)
Все сторонние Actions запинены на полный commit SHA с комментарием-версией:

| Action | Было | SHA (версия) |
|---|---|---|
| `shivammathur/setup-php` | `@v2` | `f3e473d…` (2.37.2) |
| `codecov/codecov-action` | `@v7` | `fb8b358…` (v7.0.0) |
| `docker/setup-buildx-action` | `@v4` | `bb05f3f…` (v4.2.0) |
| `docker/login-action` | `@v4` | `af1e73f…` (v4.4.0) |
| `docker/build-push-action` | `@v7` | `53b7df9…` (v7.3.0) |
| `googleapis/release-please-action` | `@v5` | `45996ed…` (v5.0.0) |

First-party actions (`actions/*`, `github/codeql-action`) правилом не флагаются и оставлены на тегах.

YAML всех воркфлоу провалидирован.