### PR TITLE
fix(docker): sessions-only volume, rolling engine tags, repair image build

### DIFF
--- a/.env.public.example
+++ b/.env.public.example
@@ -14,10 +14,23 @@ DB_PASSWORD=CHANGE_ME
 MYSQL_DATABASE=pinba
 DB_USER=pinba
 
+# ── Optional: image tags ─────────────────────────────────────────────────────
+# Pinboard: pin to a release (e.g. 2.0.0) for reproducible production deploys:
+# https://hub.docker.com/r/xolegator/pinboard/tags
+PINBOARD_TAG=latest
+# Pinba engine: rolling channel tag (8.0 / 8.4 / mariadb-10.11 / mariadb-11.8)
+# follows pinba_engine releases automatically. Pin {series}-v{version}
+# (e.g. 8.4-v2.11.3) for reproducible deploys:
+# https://hub.docker.com/r/xolegator/pinba-engine/tags
+PINBA_ENGINE_TAG=8.4
+
 # ── Optional: port mapping on the host ──────────────────────────────────────
 PINBOARD_HTTP_PORT=8080
 MYSQL_PORT=13306
 PINBA_UDP_PORT=30002
+# MySQL TCP is published on localhost only by default.
+# Set MYSQL_BIND=0.0.0.0 to allow direct DB access from other hosts.
+MYSQL_BIND=127.0.0.1
 
 # ── Optional: timezone ───────────────────────────────────────────────────────
 TZ=UTC

--- a/Dockerfile.pinboard
+++ b/Dockerfile.pinboard
@@ -23,7 +23,7 @@ RUN corepack enable && corepack prepare pnpm@9 --activate
 COPY package.json pnpm-lock.yaml .npmrc ./
 RUN pnpm install --frozen-lockfile
 
-COPY webpack.config.js ./
+COPY webpack.config.mjs ./
 COPY assets/     ./assets/
 COPY public/css/ ./public/css/
 
@@ -60,14 +60,17 @@ FROM php:8.5-fpm-alpine@sha256:82dd8cfd2aa93a98b0357e4c810f894c4ca265b5034aef3be
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # ── System packages ───────────────────────────────────────────────────────────
+# Fuzzy pins (=~) hold the feature version but tolerate Alpine -rN security
+# revisions. Do NOT use exact pins (pkg=x.y.z-rN): Alpine drops old revisions
+# from its live repo, so exact pins rot and break the post-release image build.
 RUN apk add --no-cache \
-    bash=5.3.3-r1 \
-    curl=8.19.0-r0 \
-    icu-dev=76.1-r1 \
-    nginx=1.28.3-r4 \
-    oniguruma-dev=6.9.10-r0 \
-    supervisor=4.3.0-r0 \
-    tzdata=2026b-r0 \
+    bash=~5.3 \
+    curl=~8.19 \
+    icu-dev=~76.1 \
+    nginx=~1.28 \
+    oniguruma-dev=~6.9 \
+    supervisor=~4.3 \
+    tzdata=~2026 \
  && docker-php-ext-install -j"$(nproc)" intl pdo_mysql \
  && rm -rf /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ Restart PHP-FPM and make a few requests on your site.
 
 | Image | Description |
 |---|---|
-| `xolegator/pinba-engine:8.4-lts` | MySQL 8.4 LTS with Pinba storage engine plugin |
-| `xolegator/pinboard:latest` | Pinboard web UI + aggregate worker |
+| `xolegator/pinba-engine:8.4` | MySQL 8.4 LTS with Pinba storage engine plugin |
+| `xolegator/pinboard:latest` | Pinboard web UI + aggregate worker (pin a release via `PINBOARD_TAG` in `.env`) |
+
+Aggregated history and login sessions are stored in named Docker volumes and survive restarts and upgrades; see [data persistence & backups](docs/docker.md#data-persistence--backups).
 
 The database image bundles the [XOlegator/pinba_engine](https://github.com/XOlegator/pinba_engine) plugin — a fork of the original [tony2001/pinba_engine](https://github.com/tony2001/pinba_engine) with support for MySQL 8.0 / 8.4 LTS and MariaDB 10.11 / 11.8 LTS added from a single source tree.
 

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -12,6 +12,9 @@ framework:
         cookie_secure: auto
         cookie_samesite: lax
         storage_factory_id: session.storage.factory.native
+        # Keep sessions outside kernel.cache_dir so cache rebuilds
+        # (deploys, container recreation) don't log users out.
+        save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
 
     #esi: true
     #fragments: true

--- a/docker-compose.public.yml
+++ b/docker-compose.public.yml
@@ -1,8 +1,8 @@
 # docker-compose.public.yml — Pinboard quick start
 #
 # Uses pre-built images from Docker Hub:
-#   xolegator/pinba-engine:8.4-lts   MySQL 8.4 LTS + Pinba storage engine
-#   xolegator/pinboard:latest         Pinboard web app + aggregate worker
+#   xolegator/pinba-engine:8.4      MySQL 8.4 LTS + Pinba storage engine (rolling channel)
+#   xolegator/pinboard:latest        Pinboard web app + aggregate worker
 #
 # Quick start:
 #   cp .env.public.example .env
@@ -17,12 +17,21 @@
 # PHP app on monitored hosts must send Pinba stats to:
 #   pinba.server = <this-host-ip>
 #   pinba.port   = 30002   (or PINBA_UDP_PORT from .env)
+#
+# Data persistence (see docs/docker.md#data-persistence--backups):
+#   pinba-mysql-data    aggregated history + users — survives restarts/upgrades
+#   pinboard-sessions   login sessions — survives restarts/upgrades
+#   Symfony cache is ephemeral by design: rebuilt on container recreate,
+#   so image upgrades never run against a stale compiled cache.
 
 services:
 
   # ── MySQL 8.4 LTS + Pinba storage engine ────────────────────────────────────
   pinba-db:
-    image: xolegator/pinba-engine:8.4-lts-v2.0.0
+    # Rolling channel tag: follows pinba_engine releases automatically, no
+    # reconfiguration needed. Channels: 8.0 / 8.4 / mariadb-10.11 / mariadb-11.8.
+    # Set PINBA_ENGINE_TAG={series}-v{version} (e.g. 8.4-v2.11.3) to pin.
+    image: xolegator/pinba-engine:${PINBA_ENGINE_TAG:-8.4}
     container_name: pinboard-pinba-db
     restart: unless-stopped
     environment:
@@ -31,19 +40,24 @@ services:
       MYSQL_USER: ${DB_USER:-pinba}
       MYSQL_PASSWORD: ${DB_PASSWORD:-pinba}
     ports:
-      - "${MYSQL_PORT:-13306}:3306"
+      # MySQL TCP is bound to localhost by default; set MYSQL_BIND=0.0.0.0
+      # in .env only if other hosts must query the DB directly.
+      - "${MYSQL_BIND:-127.0.0.1}:${MYSQL_PORT:-13306}:3306"
       - "${PINBA_UDP_PORT:-30002}:30002/udp"
     volumes:
       - pinba-mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
+      # $$ defers expansion to the container shell — the password is read from
+      # the container env at runtime, not baked into the compose config.
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -p\"$$MYSQL_ROOT_PASSWORD\""]
       interval: 10s
       timeout: 5s
       retries: 20
 
   # ── Pinboard web UI (nginx + php-fpm in one container) ──────────────────────
   pinboard:
-    image: xolegator/pinboard:latest
+    # Pin PINBOARD_TAG in .env to a release (e.g. 2.0.0) for reproducible deploys.
+    image: xolegator/pinboard:${PINBOARD_TAG:-latest}
     container_name: pinboard-web
     restart: unless-stopped
     depends_on:
@@ -73,11 +87,19 @@ services:
     ports:
       - "${PINBOARD_HTTP_PORT:-8080}:80"
     volumes:
-      - pinboard-var:/var/www/var
+      # Only sessions need to survive container recreation; cache and logs
+      # are ephemeral (logs go to stdout/stderr).
+      - pinboard-sessions:/var/www/var/sessions
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS -o /dev/null http://127.0.0.1/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
 
   # ── Aggregate worker (same image, cron mode) ─────────────────────────────────
   aggregate:
-    image: xolegator/pinboard:latest
+    image: xolegator/pinboard:${PINBOARD_TAG:-latest}
     container_name: pinboard-aggregate
     restart: unless-stopped
     depends_on:
@@ -93,6 +115,9 @@ services:
       DB_USER: ${DB_USER:-pinba}
       DB_PASSWORD: ${DB_PASSWORD:-pinba}
       DB_SERVER_VERSION: "8.4.0"
+      # Notification emails are sent by the aggregate run — MAILER_DSN must be
+      # set here, not only on the web container.
+      MAILER_DSN: ${MAILER_DSN:-null://null}
       TZ: ${TZ:-UTC}
       APP_AUTH_USER_SOURCE: ${APP_AUTH_USER_SOURCE:-db}
       APP_RECORDS_LIFETIME: ${APP_RECORDS_LIFETIME:-P1M}
@@ -104,9 +129,7 @@ services:
       APP_NOTIFICATION_SENDER: ${APP_NOTIFICATION_SENDER:-noreply@pinboard.local}
       APP_NOTIFICATION_GLOBAL_EMAIL: ${APP_NOTIFICATION_GLOBAL_EMAIL:-}
     command: ["supercronic", "/etc/crontabs/aggregate.cron"]
-    volumes:
-      - pinboard-var:/var/www/var
 
 volumes:
   pinba-mysql-data:
-  pinboard-var:
+  pinboard-sessions:

--- a/docker/.env
+++ b/docker/.env
@@ -16,7 +16,7 @@ NGINX_HOST_HTTP_PORT=18088
 INSTALL_XDEBUG=false
 
 # pinba mysql image published to Docker Hub
-PINBA_IMAGE=xolegator/pinba-engine:8.4-lts-v2.0.0
+PINBA_IMAGE=xolegator/pinba-engine:8.4
 
 # mysql + pinba
 MYSQL_ROOT_PASSWORD=changeme

--- a/docker/.env.mysql84
+++ b/docker/.env.mysql84
@@ -16,7 +16,7 @@ NGINX_HOST_HTTP_PORT=18088
 INSTALL_XDEBUG=false
 
 # pinba mysql image published to Docker Hub
-PINBA_IMAGE=xolegator/pinba-engine:8.4-lts-v2.0.0
+PINBA_IMAGE=xolegator/pinba-engine:8.4
 
 # mysql + pinba
 MYSQL_ROOT_PASSWORD=changeme

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,9 @@ services:
     volumes:
       - pinba-mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
+      # $$ defers expansion to the container shell — the password is read from
+      # the container env at runtime, not baked into the compose config.
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -p\"$$MYSQL_ROOT_PASSWORD\""]
       interval: 10s
       timeout: 5s
       retries: 20

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,6 +1,6 @@
 # Pinba MySQL image is maintained in the dedicated pinba_engine project.
 # This wrapper keeps compatibility for local `docker build` workflows.
-ARG PINBA_IMAGE=xolegator/pinba-engine:8.4-lts-v2.0.0
+ARG PINBA_IMAGE=xolegator/pinba-engine:8.4
 FROM ${PINBA_IMAGE}
 
 COPY ./docker/mysql-init/20-create-pinboard-user.sh /docker-entrypoint-initdb.d/20-create-pinboard-user.sh

--- a/docker/php-fpm/aggregate.cron
+++ b/docker/php-fpm/aggregate.cron
@@ -1,1 +1,1 @@
-*/15 * * * * cd /var/www && APP_ENV=${APP_ENV:-dev} APP_DEBUG=${APP_DEBUG:-0} php bin/console aggregate --no-interaction >> /var/www/var/log/aggregate-cron.log 2>&1
+*/15 * * * * cd /var/www && APP_ENV=${APP_ENV:-dev} APP_DEBUG=${APP_DEBUG:-0} php bin/console aggregate --no-interaction

--- a/docker/php-fpm/entrypoint.prod.sh
+++ b/docker/php-fpm/entrypoint.prod.sh
@@ -40,6 +40,9 @@ if [ "${1:-}" = "/usr/bin/supervisord" ]; then
 fi
 
 # ── Warm cache (web container only) ──────────────────────────────────────────
+# The cache lives on the ephemeral container filesystem (no volume), so a
+# recreated container always starts with a cache compiled from its own image —
+# never a stale cache from a previous version.
 if [ "${1:-}" = "/usr/bin/supervisord" ] && [ ! -d var/cache/prod ]; then
     echo "[pinboard] Warming up Symfony cache..."
     su -s /bin/sh www-data -c "php bin/console cache:warmup"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -15,8 +15,8 @@ Two ways to run the stack:
 ## Option A — Public images (quick-start)
 
 Uses pre-built images from Docker Hub:
-- `xolegator/pinba-engine:8.4-lts` — MySQL 8.4 LTS with Pinba storage engine
-- `xolegator/pinboard:latest` — Pinboard web app + aggregate worker
+- `xolegator/pinba-engine:8.4` — MySQL 8.4 LTS with Pinba storage engine
+- `xolegator/pinboard:latest` — Pinboard web app + aggregate worker (pin a release via `PINBOARD_TAG` in `.env`)
 
 ### Step 1 — Configure
 
@@ -37,6 +37,9 @@ Everything else has sensible defaults. Key optional overrides:
 ```env
 PINBOARD_HTTP_PORT=8080     # web UI port on your host
 PINBA_UDP_PORT=30002        # UDP port PHP apps send Pinba packets to
+PINBOARD_TAG=latest         # pin to a release tag (e.g. 2.0.0) for reproducible deploys
+PINBA_ENGINE_TAG=8.4        # rolling channel (8.0 / 8.4 / mariadb-*); pin {series}-v{version} to freeze
+MYSQL_BIND=127.0.0.1        # host interface for MySQL TCP; 0.0.0.0 to expose it
 TZ=UTC                      # timezone for aggregation timestamps
 APP_RECORDS_LIFETIME=P1M    # how long to keep raw data (ISO 8601 duration)
 ```
@@ -53,6 +56,8 @@ Three containers start:
 - `pinboard-aggregate` — supercronic running `aggregate` every 15 minutes
 
 The web container waits for the DB healthcheck to pass, then runs Doctrine migrations automatically on first boot.
+
+MySQL TCP (`13306`) is published on localhost only by default; the Pinba UDP port is published on all interfaces so monitored hosts can reach it.
 
 ### Step 3 — Create admin user
 
@@ -101,6 +106,31 @@ docker logs pinboard-aggregate
 docker exec pinboard-aggregate php bin/console aggregate --no-interaction
 ```
 
+### Data persistence & backups
+
+What survives container restarts and upgrades:
+
+| Data | Where | Survives restart / upgrade? |
+|---|---|---|
+| Aggregated history, users, settings | `pinba-mysql-data` volume (InnoDB) | yes |
+| Login sessions | `pinboard-sessions` volume | yes |
+| Raw Pinba request stream | in-memory tables (Pinba engine) | no — by design |
+| Symfony cache | container filesystem | no — rebuilt on recreate |
+| Application / cron logs | stdout/stderr | via `docker logs` |
+
+The Pinba storage engine keeps the raw request stream in memory, so restarting
+`pinboard-pinba-db` loses at most one aggregation period (15 minutes by
+default) of not-yet-aggregated data. Everything already aggregated lives in
+InnoDB tables on the `pinba-mysql-data` volume.
+
+Back up the database with `mysqldump` (raw in-memory tables are transient —
+only the aggregated data matters):
+
+```bash
+docker exec pinboard-pinba-db sh -c \
+  'mysqldump -uroot -p"$MYSQL_ROOT_PASSWORD" --databases pinba' > pinboard-backup.sql
+```
+
 ### Upgrading
 
 ```bash
@@ -108,7 +138,14 @@ docker compose -f docker-compose.public.yml pull
 docker compose -f docker-compose.public.yml up -d
 ```
 
-Migrations run automatically on container start.
+Migrations run automatically on container start, and the Symfony cache is
+compiled fresh inside the new containers — it is intentionally not stored in a
+volume, so an upgraded image never runs against a stale cache.
+
+> **Upgrading from an older compose file that used a `pinboard-var` volume:**
+> that volume is no longer referenced and can be removed
+> (`docker volume ls | grep pinboard-var`, then `docker volume rm <name>`).
+> Active logins are reset once — users simply sign in again.
 
 ### Stop / remove
 
@@ -128,7 +165,7 @@ For Pinboard contributors. Mounts source code into containers so edits are refle
 
 ### Architecture
 
-- **`mysql-pinba`** — MySQL + Pinba engine (from `xolegator/pinba-engine:8.4-lts` by default)
+- **`mysql-pinba`** — MySQL + Pinba engine (from `xolegator/pinba-engine:8.4` by default)
 - **`php-fpm`** — PHP-FPM with source mounted at `/var/www`
 - **`nginx`** — proxies HTTP to php-fpm
 - **`aggregate`** — runs `php bin/console aggregate` on cron
@@ -137,8 +174,8 @@ For Pinboard contributors. Mounts source code into containers so edits are refle
 
 | Env file | Image | Make targets |
 |---|---|---|
-| `docker/.env` (default) | `xolegator/pinba-engine:8.4-lts` | `make up`, `make build` |
-| `docker/.env.mysql84` | `xolegator/pinba-engine:8.4-lts` | `make up84`, `make build84` |
+| `docker/.env` (default) | `xolegator/pinba-engine:8.4` | `make up`, `make build` |
+| `docker/.env.mysql84` | `xolegator/pinba-engine:8.4` | `make up84`, `make build84` |
 | `docker/.env.mysql80` | `xolegator/pinba-engine:8.0` | `make up80`, `make build80` |
 
 ### Start

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
         "@babel/preset-env": "^8.0.2",
         "@popperjs/core": "^2.11.8",
         "@symfony/webpack-encore": "^7.1.0",
+        "babel-plugin-polyfill-corejs3": "^1.0.0",
         "bootstrap": "^5.3.3",
         "core-js": "^3.49.0",
         "regenerator-runtime": "^0.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@symfony/webpack-encore':
         specifier: ^7.1.0
         version: 7.1.0(@babel/core@8.0.1)(@babel/preset-env@8.0.2(@babel/core@8.0.1))(postcss@8.5.16)(sass-loader@17.0.0(sass@1.101.0)(webpack@5.108.3))(sass@1.101.0)(webpack-cli@7.1.0)(webpack-notifier@1.15.0)(webpack@5.108.3)
+      babel-plugin-polyfill-corejs3:
+        specifier: ^1.0.0
+        version: 1.0.0(@babel/core@8.0.1)
       bootstrap:
         specifier: ^5.3.3
         version: 5.3.8(@popperjs/core@2.11.8)

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -1,8 +1,10 @@
-const path = require('path');
-const Encore = require('@symfony/webpack-encore');
+// Webpack Encore 7 is ESM-only, so this config uses ESM syntax and the .mjs
+// extension (the project's package.json has no "type": "module").
+import path from 'path';
+import Encore from '@symfony/webpack-encore';
 
 // Manually configure the runtime environment if not already configured yet by the "encore" command.
-// It's useful when you use tools that rely on webpack.config.js file.
+// It's useful when you use tools that rely on the webpack config file.
 if (!Encore.isRuntimeEnvironmentConfigured()) {
     Encore.configureRuntimeEnvironment(process.env.NODE_ENV || 'dev');
 }
@@ -43,16 +45,13 @@ Encore
     // enables hashed filenames (e.g. app.abc123.css)
     .enableVersioning(Encore.isProduction())
 
-    // configure Babel
-    // .configureBabel((config) => {
-    //     config.plugins.push('@babel/a-babel-plugin');
-    // })
-
-    // enables and configure @babel/preset-env polyfills
-    .configureBabelPresetEnv((config) => {
-        config.useBuiltIns = 'usage';
-        config.corejs = '3.49';
-        config.bugfixes = true;
+    // configure Babel: core-js polyfills on demand. Babel 8 removed the
+    // useBuiltIns/corejs options from @babel/preset-env in favour of this plugin.
+    .configureBabel((config) => {
+        config.plugins.push([
+            'babel-plugin-polyfill-corejs3',
+            { method: 'usage-global', version: '3.49' },
+        ]);
     })
 
     // enables Sass/SCSS support
@@ -61,7 +60,7 @@ Encore
         options.sassOptions = {
             ...(options.sassOptions || {}),
             loadPaths: [
-                path.resolve(__dirname, 'node_modules'),
+                path.resolve(import.meta.dirname, 'node_modules'),
             ],
             quietDeps: true,
             style: Encore.isProduction() ? 'compressed' : 'expanded',
@@ -79,4 +78,4 @@ Encore
     //.enableIntegrityHashes(Encore.isProduction())
 ;
 
-module.exports = Encore.getWebpackConfig();
+export default await Encore.getWebpackConfig();


### PR DESCRIPTION
## Summary

Reworks the public Docker stack's volume/persistence model to the conventional scheme (persist data, keep caches ephemeral), fixes latent breakages around it, and updates docs.

### Volumes & persistence (the core change)
- **Drop the shared `pinboard-var` volume** that persisted the compiled Symfony cache: after `pull && up -d` the new image kept running against the previous version's cache. Cache is now ephemeral and compiled fresh on container recreate.
- Only sessions persist, in a new `pinboard-sessions` volume (web container only). Sessions moved out of `kernel.cache_dir` (`framework.session.save_path = var/sessions/%kernel.environment%`) so cache rebuilds don't log users out.
- Aggregate cron logs to stdout (`docker logs pinboard-aggregate`) instead of an unrotated file; the aggregate container needs no volume.

### Fixes
- `MAILER_DSN` is now passed to the **aggregate** service — notification emails are sent by the aggregate run, so configuring it on the web container alone silently never worked.
- pinba-engine images switched to the current **rolling channel tag `8.4`** (old `8.4-lts*` tags are stale, stuck at v2.0.0). New `PINBA_ENGINE_TAG` / `PINBOARD_TAG` overrides for pinning; engine releases require no reconfiguration here.
- `Dockerfile.pinboard`: fuzzy apk pins (`=~`) tolerate Alpine `-rN` security bumps that previously broke post-release image builds.
- Frontend: migrate to Encore 7 ESM config (`webpack.config.mjs`) + Babel 8 polyfills (`babel-plugin-polyfill-corejs3`) — **the image build has been broken since the npm group bump (#177)**; CI doesn't build the frontend, so it only surfaced in `docker build`.

### Hardening
- MySQL TCP published on `127.0.0.1` by default (`MYSQL_BIND` to override); Pinba UDP stays on all interfaces.
- DB healthcheck expands the password at runtime (`$$`) instead of baking it into the compose config; new web-container healthcheck.

### Docs
- New “Data persistence & backups” section (what survives restarts, mysqldump example), upgrade notes incl. removing the legacy `pinboard-var` volume, tag guidance; README / `.env.public.example` synced.

## Verification
- Full `docker build -f Dockerfile.pinboard` passes; 52 PHPUnit tests green; both compose files validate.
- Live smoke test of the public stack: migrations auto-ran, `/login` 200, admin user created, form login OK, aggregation ran in the separate container, cron output visible via `docker logs`, and **a logged-in session survived `--force-recreate` of the web container with a freshly compiled cache**.

## Upgrade note for existing deployments
The old `pinboard-var` volume is no longer referenced and can be removed; active logins reset once.