### PR TITLE
fix(docker): move pinboard runtime and widen host fields

### DIFF
--- a/Dockerfile.pinboard
+++ b/Dockerfile.pinboard
@@ -107,7 +107,7 @@ RUN addgroup -g 1000 -S www-data 2>/dev/null || true \
  && adduser  -u 1000 -S -D -G www-data www-data 2>/dev/null || true
 
 # ── Application ──────────────────────────────────────────────────────────────
-WORKDIR /var/www
+WORKDIR /var/www/pinboard
 
 # PHP vendor (production, no dev, optimized autoloader)
 COPY --from=composer-builder --chown=www-data:www-data /build/vendor ./vendor

--- a/docker-compose.public.yml
+++ b/docker-compose.public.yml
@@ -89,7 +89,7 @@ services:
     volumes:
       # Only sessions need to survive container recreation; cache and logs
       # are ephemeral (logs go to stdout/stderr).
-      - pinboard-sessions:/var/www/var/sessions
+      - pinboard-sessions:/var/www/pinboard/var/sessions
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS -o /dev/null http://127.0.0.1/"]
       interval: 30s

--- a/docker/nginx/default.prod.conf
+++ b/docker/nginx/default.prod.conf
@@ -2,7 +2,7 @@ server {
     listen 80;
     listen [::]:80;
 
-    root /var/www/public;
+    root /var/www/pinboard/public;
     index index.php index.html;
 
     location / {

--- a/docker/php-fpm/aggregate.cron
+++ b/docker/php-fpm/aggregate.cron
@@ -1,1 +1,1 @@
-*/15 * * * * cd /var/www && APP_ENV=${APP_ENV:-dev} APP_DEBUG=${APP_DEBUG:-0} php bin/console aggregate --no-interaction
+*/15 * * * * cd /var/www/pinboard && APP_ENV=${APP_ENV:-dev} APP_DEBUG=${APP_DEBUG:-0} php bin/console aggregate --no-interaction

--- a/migrations/Version20260716120000.php
+++ b/migrations/Version20260716120000.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260716120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Increase hostname columns from varchar(32) to varchar(64) in Pinboard-managed tables';
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->widenColumn('ipm_report_2_by_hostname_and_server', 'hostname');
+        $this->widenColumn('ipm_report_by_hostname', 'hostname');
+        $this->widenColumn('ipm_report_by_hostname_and_server', 'hostname');
+        $this->widenColumn('ipm_status_details', 'hostname');
+        $this->widenColumn('ipm_req_time_details', 'hostname');
+        $this->widenColumn('ipm_mem_peak_usage_details', 'hostname');
+        $this->widenColumn('ipm_pinba_report_by_hostname_and_server_90_95_99', 'hostname');
+        $this->widenColumn('ipm_pinba_report_by_hostname_90_95_99', 'hostname');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->narrowColumn('ipm_report_2_by_hostname_and_server', 'hostname');
+        $this->narrowColumn('ipm_report_by_hostname', 'hostname');
+        $this->narrowColumn('ipm_report_by_hostname_and_server', 'hostname');
+        $this->narrowColumn('ipm_status_details', 'hostname');
+        $this->narrowColumn('ipm_req_time_details', 'hostname');
+        $this->narrowColumn('ipm_mem_peak_usage_details', 'hostname');
+        $this->narrowColumn('ipm_pinba_report_by_hostname_and_server_90_95_99', 'hostname');
+        $this->narrowColumn('ipm_pinba_report_by_hostname_90_95_99', 'hostname');
+    }
+
+    private function widenColumn(string $table, string $column): void
+    {
+        if ($this->hasColumnWithLength($table, $column, 32)) {
+            $this->addSql(sprintf(
+                'ALTER TABLE `%s` MODIFY `%s` varchar(64) DEFAULT NULL',
+                $table,
+                $column,
+            ));
+        }
+    }
+
+    private function narrowColumn(string $table, string $column): void
+    {
+        if ($this->hasColumnWithLength($table, $column, 64)) {
+            $this->addSql(sprintf(
+                'ALTER TABLE `%s` MODIFY `%s` varchar(32) DEFAULT NULL',
+                $table,
+                $column,
+            ));
+        }
+    }
+
+    private function hasColumnWithLength(string $table, string $column, int $length): bool
+    {
+        $actualLength = $this->connection->fetchOne(
+            'SELECT CHARACTER_MAXIMUM_LENGTH
+             FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = :table
+               AND COLUMN_NAME = :column',
+            [
+                'table' => $table,
+                'column' => $column,
+            ],
+        );
+
+        return is_numeric($actualLength) && (int) $actualLength === $length;
+    }
+}

--- a/migrations/Version20260716120000.php
+++ b/migrations/Version20260716120000.php
@@ -27,8 +27,6 @@ final class Version20260716120000 extends AbstractMigration
         $this->widenColumn('ipm_status_details', 'hostname');
         $this->widenColumn('ipm_req_time_details', 'hostname');
         $this->widenColumn('ipm_mem_peak_usage_details', 'hostname');
-        $this->widenColumn('ipm_pinba_report_by_hostname_and_server_90_95_99', 'hostname');
-        $this->widenColumn('ipm_pinba_report_by_hostname_90_95_99', 'hostname');
     }
 
     public function down(Schema $schema): void
@@ -39,8 +37,6 @@ final class Version20260716120000 extends AbstractMigration
         $this->narrowColumn('ipm_status_details', 'hostname');
         $this->narrowColumn('ipm_req_time_details', 'hostname');
         $this->narrowColumn('ipm_mem_peak_usage_details', 'hostname');
-        $this->narrowColumn('ipm_pinba_report_by_hostname_and_server_90_95_99', 'hostname');
-        $this->narrowColumn('ipm_pinba_report_by_hostname_90_95_99', 'hostname');
     }
 
     private function widenColumn(string $table, string $column): void


### PR DESCRIPTION
## Summary
- move the production image runtime from /var/www to /var/www/pinboard
- update the related production nginx, cron, and public compose session paths
- add a migration that widens Pinboard-managed hostname columns from varchar(32) to varchar(64)

## Verification
- php -l migrations/Version20260716120000.php