### PR TITLE
chore(config): disable transactional doctrine migrations

### DIFF
--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -3,4 +3,7 @@ doctrine_migrations:
         # namespace is arbitrary but should be different from App\Migrations
         # as migrations classes should NOT be autoloaded
         'DoctrineMigrations': '%kernel.project_dir%/migrations'
+    # MySQL performs implicit commits around DDL, so wrapping migrations in a
+    # transaction triggers deprecation warnings in doctrine/migrations.
+    transactional: false
     enable_profiler: false


### PR DESCRIPTION
## Summary
- disable transactional Doctrine migrations by default for this Symfony app
- avoid doctrine/migrations deprecation warnings on MySQL when schema migrations trigger implicit DDL commits
- keep the change scoped to migration runtime configuration only

## Verification
- built the production image locally with the updated config
- `docker run --rm --network pinboard_default -e APP_ENV=prod -e APP_DEBUG=0 -e APP_SECRET=testsecret -e DB_HOST=pinboard-pinba-db -e DB_PORT=3306 -e DB_NAME=pinba -e DB_USER=pinba -e DB_PASSWORD=pinboard-app -e DB_SERVER_VERSION=8.4.0 -e APP_AUTH_USER_SOURCE=db --entrypoint php xolegator/pinboard:codex-test /var/www/pinboard/bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration`
- confirmed the migration command completes without the earlier doctrine deprecation warning
