### PR TITLE
fix(docker): refresh php alpine pins

### DIFF
--- a/Dockerfile.pinboard
+++ b/Dockerfile.pinboard
@@ -62,7 +62,7 @@ RUN composer dump-autoload \
 ###############################################################################
 # Stage 3 — Runtime: PHP-FPM + Nginx + Supervisord
 ###############################################################################
-FROM php:8.5-fpm-alpine@sha256:82dd8cfd2aa93a98b0357e4c810f894c4ca265b5034aef3be654faae5f579487 AS runtime
+FROM php:8.5-fpm-alpine@sha256:79def1d16ece3ab1a6656c46a23bfd80ad33887fbd33626e7bd743cef54ef9c6 AS runtime
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # ── System packages ───────────────────────────────────────────────────────────
@@ -70,12 +70,12 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # revisions. Do NOT use exact pins (pkg=x.y.z-rN): Alpine drops old revisions
 # from its live repo, so exact pins rot and break the post-release image build.
 RUN apk add --no-cache \
-    bash=~5 \
-    curl=~8 \
-    icu-dev=~76 \
-    nginx=~1.28 \
+    bash=~5.3 \
+    curl=~8.21 \
+    icu-dev=~78 \
+    nginx=~1.30 \
     oniguruma-dev=~6.9 \
-    supervisor=~4 \
+    supervisor=~4.3 \
     tzdata=~2026 \
  && docker-php-ext-install -j"$(nproc)" intl pdo_mysql \
  && rm -rf /var/cache/apk/*

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5-fpm-alpine@sha256:82dd8cfd2aa93a98b0357e4c810f894c4ca265b5034aef3be654faae5f579487
+FROM php:8.5-fpm-alpine@sha256:79def1d16ece3ab1a6656c46a23bfd80ad33887fbd33626e7bd743cef54ef9c6
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Latest release should be periodically revalidated against aptible/supercronic.
@@ -8,13 +8,13 @@ ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v${
     SUPERCRONIC=supercronic-linux-amd64
 
 RUN apk add --no-cache \
-    bash=5.3.3-r1 \
-    curl=8.19.0-r0 \
-    git=2.52.0-r0 \
-    icu-dev=76.1-r1 \
-    libzip-dev=1.11.4-r1 \
+    bash=5.3.9-r1 \
+    curl=8.21.0-r0 \
+    git=2.54.0-r0 \
+    icu-dev=78.1-r0 \
+    libzip-dev=1.11.4-r2 \
     oniguruma-dev=6.9.10-r0 \
-    tzdata=2026b-r0 \
+    tzdata=2026c-r0 \
     unzip=6.0-r16 \
     zip=3.0-r13 \
  && docker-php-ext-install -j"$(nproc)" pdo_mysql intl

--- a/src/Command/AggregateCommand.php
+++ b/src/Command/AggregateCommand.php
@@ -19,6 +19,7 @@ use Twig\Environment;
 class AggregateCommand extends Command
 {
     private const float MYSQL_DOUBLE_MAX = 1.7976931348623157e308;
+    private const float PINBA_FLOAT_MAX = 3.4028234663852886e38;
     private const string MYSQL_NUMERIC_PATTERN = '^-?([0-9]+(\\.[0-9]+)?|\\.[0-9]+)([eE][+-]?[0-9]+)?$';
 
     private AggregateConfig $config;
@@ -188,9 +189,13 @@ class AggregateCommand extends Command
         // Normalize through CHAR first to avoid MySQL warning on malformed
         // numeric payloads coming from Pinba virtual tables before CASE can
         // short-circuit. Scientific notation is accepted for large values.
+        // Pinba engine percentiles are exposed as FLOAT columns; FLT_MAX-like
+        // values (for example 3.40282e38) are treated as broken sentinels and
+        // are nulled instead of being persisted into report tables.
         return sprintf(
             "CASE
                 WHEN TRIM(CONVERT(%1\$s, CHAR)) REGEXP '%2\$s'
+                    AND ABS(CAST(TRIM(CONVERT(%1\$s, CHAR)) AS DOUBLE)) < %4\$s
                     THEN LEAST(
                         GREATEST(CAST(TRIM(CONVERT(%1\$s, CHAR)) AS DOUBLE), -%3\$s),
                         %3\$s
@@ -199,7 +204,8 @@ class AggregateCommand extends Command
             END",
             $expression,
             self::MYSQL_NUMERIC_PATTERN,
-            self::MYSQL_DOUBLE_MAX
+            self::MYSQL_DOUBLE_MAX,
+            self::PINBA_FLOAT_MAX
         );
     }
 

--- a/tests/Unit/Command/AggregateCommandConfigTest.php
+++ b/tests/Unit/Command/AggregateCommandConfigTest.php
@@ -211,6 +211,7 @@ final class AggregateCommandConfigTest extends TestCase
         self::assertIsString($sql);
         self::assertStringContainsString("TRIM(CONVERT(p90, CHAR)) REGEXP '^-?([0-9]+(\\.[0-9]+)?|\\.[0-9]+)([eE][+-]?[0-9]+)?$'", $sql);
         self::assertStringContainsString('CAST(TRIM(CONVERT(p90, CHAR)) AS DOUBLE)', $sql);
+        self::assertMatchesRegularExpression('/ABS\\(CAST\\(TRIM\\(CONVERT\\(p90, CHAR\\)\\) AS DOUBLE\\)\\) < 3\\.4028234663852\\d*E\\+38/', $sql);
         self::assertMatchesRegularExpression('/-1\\.7976931348623\\d*E\\+308/', $sql);
         self::assertMatchesRegularExpression('/[^-]1\\.7976931348623\\d*E\\+308/', $sql);
         self::assertStringContainsString('ELSE NULL', $sql);

--- a/tests/Unit/Command/AggregateCommandConfigTest.php
+++ b/tests/Unit/Command/AggregateCommandConfigTest.php
@@ -211,7 +211,7 @@ final class AggregateCommandConfigTest extends TestCase
         self::assertIsString($sql);
         self::assertStringContainsString("TRIM(CONVERT(p90, CHAR)) REGEXP '^-?([0-9]+(\\.[0-9]+)?|\\.[0-9]+)([eE][+-]?[0-9]+)?$'", $sql);
         self::assertStringContainsString('CAST(TRIM(CONVERT(p90, CHAR)) AS DOUBLE)', $sql);
-        self::assertMatchesRegularExpression('/ABS\\(CAST\\(TRIM\\(CONVERT\\(p90, CHAR\\)\\) AS DOUBLE\\)\\) < 3\\.4028234663852\\d*E\\+38/', $sql);
+        self::assertMatchesRegularExpression('/ABS\\(CAST\\(TRIM\\(CONVERT\\(p90, CHAR\\)\\) AS DOUBLE\\)\\) < 3\\.402823466385[23]\\d*E\\+38/', $sql);
         self::assertMatchesRegularExpression('/-1\\.7976931348623\\d*E\\+308/', $sql);
         self::assertMatchesRegularExpression('/[^-]1\\.7976931348623\\d*E\\+308/', $sql);
         self::assertStringContainsString('ELSE NULL', $sql);


### PR DESCRIPTION
Refreshes the pinned php:8.5-fpm-alpine digest and Alpine package pins in the two runtime Dockerfiles so they match the current repository state again.

Verification:
- git diff --check
- docker build -f docker/php-fpm/Dockerfile .
- docker build -f Dockerfile.pinboard .

Neighbor Dockerfiles under docker/nginx and docker/mysql were reviewed and left unchanged because they only wrap already pinned base images.