### PR TITLE
fix(aggregate): reject rounded float sentinels

### DIFF
--- a/src/Command/AggregateCommand.php
+++ b/src/Command/AggregateCommand.php
@@ -19,7 +19,7 @@ use Twig\Environment;
 class AggregateCommand extends Command
 {
     private const float MYSQL_DOUBLE_MAX = 1.7976931348623157e308;
-    private const float PINBA_FLOAT_MAX = 3.4028234663852886e38;
+    private const float PINBA_FLOAT_SENTINEL_MAX = 3.4e38;
     private const string MYSQL_NUMERIC_PATTERN = '^-?([0-9]+(\\.[0-9]+)?|\\.[0-9]+)([eE][+-]?[0-9]+)?$';
 
     private AggregateConfig $config;
@@ -190,8 +190,9 @@ class AggregateCommand extends Command
         // numeric payloads coming from Pinba virtual tables before CASE can
         // short-circuit. Scientific notation is accepted for large values.
         // Pinba engine percentiles are exposed as FLOAT columns; FLT_MAX-like
-        // values (for example 3.40282e38) are treated as broken sentinels and
-        // are nulled instead of being persisted into report tables.
+        // values (for example 3.40282e38, which is the rounded string form of
+        // the 32-bit float sentinel) are treated as broken sentinels and are
+        // nulled instead of being persisted into report tables.
         return sprintf(
             "CASE
                 WHEN TRIM(CONVERT(%1\$s, CHAR)) REGEXP '%2\$s'
@@ -205,7 +206,7 @@ class AggregateCommand extends Command
             $expression,
             self::MYSQL_NUMERIC_PATTERN,
             self::MYSQL_DOUBLE_MAX,
-            self::PINBA_FLOAT_MAX
+            self::PINBA_FLOAT_SENTINEL_MAX
         );
     }
 

--- a/tests/Unit/Command/AggregateCommandConfigTest.php
+++ b/tests/Unit/Command/AggregateCommandConfigTest.php
@@ -211,10 +211,21 @@ final class AggregateCommandConfigTest extends TestCase
         self::assertIsString($sql);
         self::assertStringContainsString("TRIM(CONVERT(p90, CHAR)) REGEXP '^-?([0-9]+(\\.[0-9]+)?|\\.[0-9]+)([eE][+-]?[0-9]+)?$'", $sql);
         self::assertStringContainsString('CAST(TRIM(CONVERT(p90, CHAR)) AS DOUBLE)', $sql);
-        self::assertMatchesRegularExpression('/ABS\\(CAST\\(TRIM\\(CONVERT\\(p90, CHAR\\)\\) AS DOUBLE\\)\\) < 3\\.402823466385[23]\\d*E\\+38/', $sql);
+        self::assertMatchesRegularExpression('/ABS\\(CAST\\(TRIM\\(CONVERT\\(p90, CHAR\\)\\) AS DOUBLE\\)\\) < 3\\.4E\\+38/', $sql);
         self::assertMatchesRegularExpression('/-1\\.7976931348623\\d*E\\+308/', $sql);
         self::assertMatchesRegularExpression('/[^-]1\\.7976931348623\\d*E\\+308/', $sql);
         self::assertStringContainsString('ELSE NULL', $sql);
+    }
+
+    public function testSafePinbaFloatRejectsRoundedFloatMaxSentinelValues(): void
+    {
+        $command = $this->command();
+
+        $sql = $this->invoke($command, 'safePinbaFloat', 'p90');
+
+        self::assertIsString($sql);
+        self::assertStringContainsString('3.4E+38', $sql);
+        self::assertStringNotContainsString('3.4028234663852886E+38', $sql);
     }
 
     public function testSafePinbaPercentilesBuildsAliasedGuardedSelectList(): void


### PR DESCRIPTION
Pinba percentile sentinels can be rendered as rounded values like 3.40282e38. The previous guard used the exact 32-bit float max and let these values through, which still triggered MySQL 8.4 strict truncation warnings during aggregate.

This narrows the cutoff to a sentinel-specific threshold so rounded FLT_MAX-like inputs are nulled before they reach report tables.

Verification:
- php85 -l src/Command/AggregateCommand.php
- php85 -l tests/Unit/Command/AggregateCommandConfigTest.php
- php85 vendor/bin/phpunit