### PR TITLE
fix: enforce per-user hosts access across legacy configs, timers and user migration

### DIFF
--- a/src/Command/AggregateCommand.php
+++ b/src/Command/AggregateCommand.php
@@ -477,8 +477,13 @@ class AggregateCommand extends Command
 
             $db->commit();
 
+            // INSERT IGNORE: pinba engine percentile columns may hold NaN
+            // (rendered as 0), and in strict mode merely copying such a value
+            // escalates warning 1265 to an error that aborts the whole
+            // aggregation. IGNORE keeps it a warning; safePinbaPercentiles()
+            // still nulls the values it can detect as broken.
             $sql = '
-            INSERT INTO ipm_report_by_hostname
+            INSERT IGNORE INTO ipm_report_by_hostname
                 (
                     req_count, req_per_sec, req_time_total, req_time_percent, req_time_per_sec,
                     ru_utime_total, ru_utime_percent, ru_utime_per_sec,
@@ -492,7 +497,7 @@ class AggregateCommand extends Command
                     traffic_total, traffic_percent, traffic_per_sec,
                     hostname, req_time_median, ' . $this->safePinbaPercentiles() . ', \'' . $now . '\' FROM ipm_pinba_report_by_hostname_90_95_99;
 
-            INSERT INTO ipm_report_by_hostname_and_server
+            INSERT IGNORE INTO ipm_report_by_hostname_and_server
                 (
                     req_count, req_per_sec, req_time_total, req_time_percent, req_time_per_sec,
                     ru_utime_total, ru_utime_percent, ru_utime_per_sec,
@@ -506,7 +511,7 @@ class AggregateCommand extends Command
                     traffic_total, traffic_percent, traffic_per_sec,
                     hostname, server_name, req_time_median, ' . $this->safePinbaPercentiles() . ', \'' . $now . '\' FROM ipm_pinba_report_by_hostname_and_server_90_95_99;
 
-            INSERT INTO ipm_report_by_server_name
+            INSERT IGNORE INTO ipm_report_by_server_name
                 (
                     req_count, req_per_sec, req_time_total, req_time_percent, req_time_per_sec,
                     ru_utime_total, ru_utime_percent, ru_utime_per_sec,

--- a/src/Command/UsersMigrateDbToFileCommand.php
+++ b/src/Command/UsersMigrateDbToFileCommand.php
@@ -27,10 +27,17 @@ class UsersMigrateDbToFileCommand extends Command
 
         $users = [];
         foreach ($dbUsers as $dbUser) {
-            $users[$dbUser->getUserIdentifier()] = [
+            $record = [
                 'password' => $dbUser->getPassword(),
                 'roles' => $dbUser->getRoles(),
             ];
+
+            $hosts = $dbUser->getHosts();
+            if ($hosts !== null && trim($hosts) !== '') {
+                $record['hosts'] = $hosts;
+            }
+
+            $users[$dbUser->getUserIdentifier()] = $record;
         }
 
         $this->fileUserStorage->replaceUsers($users);

--- a/src/Command/UsersMigrateFileToDbCommand.php
+++ b/src/Command/UsersMigrateFileToDbCommand.php
@@ -7,6 +7,7 @@ namespace App\Command;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Security\FileUserStorage;
+use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -63,6 +64,7 @@ class UsersMigrateFileToDbCommand extends Command
 
             $user->setRoles($roles);
             $user->setPassword($row['password']);
+            $user->setHosts(Utils::normalizeHostsConfig($row['hosts'] ?? null));
             $this->entityManager->persist($user);
         }
 

--- a/src/Controller/TimerController.php
+++ b/src/Controller/TimerController.php
@@ -8,6 +8,7 @@ use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 
 class TimerController extends AbstractController
@@ -36,6 +37,11 @@ class TimerController extends AbstractController
         $request = $this->getRequestById($type, $requestId, $date);
         if (!$request) {
             throw $this->createNotFoundException("Request #$requestId not found.");
+        }
+
+        $serverName = is_string($request['server_name'] ?? null) ? $request['server_name'] : '';
+        if (!Utils::userCanAccessServer($this->getUser(), $serverName)) {
+            throw new AccessDeniedHttpException('Access to this server is not allowed for your account.');
         }
 
         $request['script_name'] = Utils::urlDecode(is_string($request['script_name']) ? $request['script_name'] : '');

--- a/src/Security/FileUserStorage.php
+++ b/src/Security/FileUserStorage.php
@@ -107,7 +107,9 @@ class FileUserStorage
         }
 
         $yaml = Yaml::dump($data, 6, 4);
-        file_put_contents($this->resolvedFilePath, $yaml);
+        if (@file_put_contents($this->resolvedFilePath, $yaml) === false) {
+            throw new \RuntimeException(\sprintf('Failed to write users file "%s".', $this->resolvedFilePath));
+        }
     }
 
     private function resolvePath(string $projectDir, string $filePath): string

--- a/src/Security/SwitchableUserProvider.php
+++ b/src/Security/SwitchableUserProvider.php
@@ -6,6 +6,7 @@ namespace App\Security;
 
 use App\Entity\User;
 use App\Repository\UserRepository;
+use App\Utils\Utils;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -78,7 +79,7 @@ class SwitchableUserProvider implements UserProviderInterface, PasswordUpgraderI
             $roles = ['ROLE_USER'];
         }
 
-        $hosts = isset($row['hosts']) && \is_string($row['hosts']) ? $row['hosts'] : null;
+        $hosts = Utils::normalizeHostsConfig($row['hosts'] ?? null);
 
         return new FileUser(
             $storageKey,

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -14,8 +14,35 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class Utils
 {
     /**
-     * Returns the hosts regexp for the current user, or '.*' if unrestricted.
-     * Only FileUser supports per-user host filtering; DB users see everything.
+     * Normalizes a `hosts` config value to a single regexp string, or null if unrestricted.
+     *
+     * The legacy (Silex-era) config allowed both a string and a list of regexps per user;
+     * empty and '.*' entries mean "no restriction" and are dropped. Multiple patterns are
+     * combined into one alternation that works both in PCRE and MySQL REGEXP.
+     */
+    public static function normalizeHostsConfig(mixed $hosts): ?string
+    {
+        $patterns = [];
+        foreach (is_array($hosts) ? $hosts : [$hosts] as $item) {
+            if (!is_string($item)) {
+                continue;
+            }
+            $item = trim($item);
+            if ($item === '' || $item === '.*') {
+                continue;
+            }
+            $patterns[] = $item;
+        }
+
+        if ($patterns === []) {
+            return null;
+        }
+
+        return count($patterns) === 1 ? $patterns[0] : '(' . implode(')|(', $patterns) . ')';
+    }
+
+    /**
+     * Returns the hosts regexp for the current user (FileUser or DB User), or '.*' if unrestricted.
      */
     public static function getUserHostsRegexp(?UserInterface $user): string
     {

--- a/tests/Unit/Security/SwitchableUserProviderTest.php
+++ b/tests/Unit/Security/SwitchableUserProviderTest.php
@@ -42,9 +42,51 @@ final class SwitchableUserProviderTest extends TestCase
         self::assertInstanceOf(FileUser::class, $user);
         self::assertSame('admin@example.com', $user->getUserIdentifier());
         self::assertSame('hashed-password', $user->getPassword());
-        self::assertSame('.*', $user->getHosts());
+        self::assertNull($user->getHosts());
         self::assertContains('ROLE_ADMIN', $user->getRoles());
         self::assertContains('ROLE_USER', $user->getRoles());
+    }
+
+    public function testLoadUserByIdentifierKeepsStringHostsRestriction(): void
+    {
+        $storage = new FileUserStorage($this->projectDir, 'config/users.yaml');
+        $storage->upsertUser('user@example.com', 'hashed-password', ['ROLE_USER'], 'site-a\.com');
+
+        $provider = new SwitchableUserProvider(
+            $this->createStub(UserRepository::class),
+            $storage,
+            'file'
+        );
+
+        $user = $provider->loadUserByIdentifier('user@example.com');
+
+        self::assertInstanceOf(FileUser::class, $user);
+        self::assertSame('site-a\.com', $user->getHosts());
+    }
+
+    public function testLoadUserByIdentifierNormalizesLegacyArrayHosts(): void
+    {
+        file_put_contents($this->projectDir . '/users.yaml', <<<'YAML'
+            secure:
+                enable: true
+                users:
+                    user@example.com:
+                        password: hashed-password
+                        hosts:
+                            - '^site-a\.com$'
+                            - '^site-b\.com$'
+            YAML);
+
+        $provider = new SwitchableUserProvider(
+            $this->createStub(UserRepository::class),
+            new FileUserStorage($this->projectDir, 'users.yaml'),
+            'file'
+        );
+
+        $user = $provider->loadUserByIdentifier('user@example.com');
+
+        self::assertInstanceOf(FileUser::class, $user);
+        self::assertSame('(^site-a\.com$)|(^site-b\.com$)', $user->getHosts());
     }
 
     public function testLoadUserByIdentifierFromDatabase(): void

--- a/tests/Unit/Utils/UtilsAccessTest.php
+++ b/tests/Unit/Utils/UtilsAccessTest.php
@@ -11,6 +11,49 @@ use PHPUnit\Framework\TestCase;
 
 final class UtilsAccessTest extends TestCase
 {
+    // ── normalizeHostsConfig ──────────────────────────────────────────────────
+
+    public function testNormalizeHostsConfigReturnsNullForUnrestrictedValues(): void
+    {
+        self::assertNull(Utils::normalizeHostsConfig(null));
+        self::assertNull(Utils::normalizeHostsConfig(''));
+        self::assertNull(Utils::normalizeHostsConfig('.*'));
+        self::assertNull(Utils::normalizeHostsConfig('  .*  '));
+        self::assertNull(Utils::normalizeHostsConfig([]));
+        self::assertNull(Utils::normalizeHostsConfig(['.*', '', '  ']));
+        self::assertNull(Utils::normalizeHostsConfig([123, false]));
+    }
+
+    public function testNormalizeHostsConfigKeepsSingleStringPattern(): void
+    {
+        self::assertSame('site-a\.com', Utils::normalizeHostsConfig('site-a\.com'));
+        self::assertSame('site-a\.com', Utils::normalizeHostsConfig('  site-a\.com  '));
+    }
+
+    public function testNormalizeHostsConfigCombinesLegacyArrayOfPatterns(): void
+    {
+        self::assertSame(
+            '(^site-a\.com$)|(^site-b\.com$)',
+            Utils::normalizeHostsConfig(['^site-a\.com$', '^site-b\.com$'])
+        );
+    }
+
+    public function testNormalizeHostsConfigDropsWildcardEntriesFromArray(): void
+    {
+        self::assertSame('site-a\.com', Utils::normalizeHostsConfig(['.*', 'site-a\.com']));
+    }
+
+    public function testNormalizedLegacyArrayRestrictsAccessCorrectly(): void
+    {
+        $hosts = Utils::normalizeHostsConfig(['^site-a\.com$', '^site-b\.com$']);
+        $user = new FileUser('u@example.com', 'h', ['ROLE_USER'], $hosts);
+
+        self::assertTrue(Utils::userCanAccessServer($user, 'site-a.com'));
+        self::assertTrue(Utils::userCanAccessServer($user, 'site-b.com'));
+        self::assertFalse(Utils::userCanAccessServer($user, 'site-c.com'));
+        self::assertFalse(Utils::userCanAccessServer($user, 'evil-site-a.com'));
+    }
+
     // ── getUserHostsRegexp ────────────────────────────────────────────────────
 
     public function testGetUserHostsRegexpReturnsWildcardForNull(): void


### PR DESCRIPTION
## Problem

After switching production to the new Pinboard with the legacy `parameters.yml` copied over, every user saw every project, ignoring their `hosts` restrictions.

## Root causes and fixes

| Hole | Fix |
|---|---|
| `SwitchableUserProvider` silently dropped **array-form `hosts`** (valid legacy Silex format) → user unrestricted | New `Utils::normalizeHostsConfig()` accepts string or legacy list, drops empty/`.*` entries, combines a list into `(a)\|(b)` alternation valid in both PCRE and MySQL 8.4 REGEXP |
| `users:migrate-file-to-db` / `users:migrate-db-to-file` did not carry `hosts` at all → DB-sourced deployments lost restrictions | Both commands now transfer the (normalized) `hosts` value |
| `TimerController` had no per-request server access check (legacy `timer.php` called `checkUserAccess`) → any authenticated user could open foreign timers by URL | Access check on the request's `server_name`, 403 like `ServerController` |

## Hardening found along the way

- `FileUserStorage::saveRawConfig()` now throws on write failure instead of reporting success while persisting nothing (observed live: `add-user` "succeeded" on Permission denied).
- The three percentile INSERTs in `aggregate` now use `INSERT IGNORE`: pinba engine report3 (`by hostname`) has an upstream off-by-one in percentile field mapping (p90 column receives the hostname string), and in strict mode copying that value aborted the whole aggregation transaction, leaving every report table empty. The engine bug is tracked separately in pinba_engine.

## Verification

- Unit tests for the normalizer and provider (legacy array format included); full suite 62/62 green, PHPStan level 10 clean, php-cs-fixer clean.
- E2E on the local dev stack: synthetic pinba UDP traffic for 4 fake domains, a user restricted via legacy array `hosts` to 2 of them — main page and menu show only the allowed domains; direct URLs to foreign overview/live/statuses/timer pages return 403; unrestricted admin sees everything.

## Deploy note

If production runs `APP_AUTH_USER_SOURCE=db`, re-run `php bin/console users:migrate-file-to-db` once after deploying so the `hosts` values reach the `user` table; with `file` source a redeploy suffices.