### PR TITLE
fix(time): use server timezone on live and overview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           key: phpstan-${{ hashFiles('phpstan.neon', 'composer.lock') }}
           restore-keys: phpstan-
 
-      - run: vendor/bin/phpstan analyse --no-progress
+      - run: vendor/bin/phpstan analyse --no-progress --memory-limit=1G
 
   phpunit:
     name: PHPUnit (PHP ${{ matrix.php }})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,9 @@
 - Backend sanity checks: `php -l` for touched PHP files and `php bin/console lint:twig` for touched Twig files.
 - PHP unit and functional tests: `vendor/bin/phpunit`.
 - PHP style: `vendor/bin/php-cs-fixer fix --dry-run --diff` — fix violations with `vendor/bin/php-cs-fixer fix`.
-- PHP static analysis: `vendor/bin/phpstan analyse --no-progress` — runs at **level 10** (maximum).
+- PHP static analysis: `vendor/bin/phpstan analyse --no-progress --memory-limit=1G` — runs at **level 10** (maximum).
 - Frontend rebuild: `pnpm build`.
-- Before pushing or opening a PR with PHP code changes, run `vendor/bin/php-cs-fixer fix --dry-run --diff` and `vendor/bin/phpstan analyse --no-progress` locally.
+- Before pushing or opening a PR with PHP code changes, run `vendor/bin/php-cs-fixer fix --dry-run --diff` and `vendor/bin/phpstan analyse --no-progress --memory-limit=1G` locally.
 - Prefer focused verification over broad test runs unless the change spans multiple layers.
 
 ## PHP Static Analysis Rules

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ DOCKER_COMPOSE_PHP_FPM_EXEC = ${DOCKER_COMPOSE} exec -u www-data php-fpm
 DOCKER_COMPOSE_TEST = docker compose --env-file ./docker/.env.test -f ./docker/docker-compose.yml -f ./docker/docker-compose.test.yml
 DOCKER_COMPOSE_TEST_PHP = ${DOCKER_COMPOSE_TEST} exec -u www-data php-fpm
 DOCKER_COMPOSE_TEST_NODE = ${DOCKER_COMPOSE_TEST} exec node
+PHPSTAN_MEMORY_LIMIT ?= 1G
 
 .PHONY: build build80 build84 start stop up up80 up84 down restart dc_ps dc_logs dc_down dc_restart \
 	app_bash php test test-up test-deps test-migrate test-check test-down test-reset cache db_migrate migrate \
@@ -85,7 +86,7 @@ test-check:
 	${DOCKER_COMPOSE_TEST_PHP} php bin/console lint:twig
 	${DOCKER_COMPOSE_TEST_PHP} vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no
 	${DOCKER_COMPOSE_TEST_PHP} env APP_ENV=dev APP_DEBUG=1 php bin/console cache:warmup
-	${DOCKER_COMPOSE_TEST_PHP} vendor/bin/phpstan analyse --no-progress --memory-limit=1G
+	${DOCKER_COMPOSE_TEST_PHP} vendor/bin/phpstan analyse --no-progress --memory-limit=${PHPSTAN_MEMORY_LIMIT}
 	${DOCKER_COMPOSE_TEST_PHP} vendor/bin/phpunit --no-progress
 	${DOCKER_COMPOSE_TEST_NODE} sh -lc 'COREPACK_HOME=/tmp/corepack corepack pnpm build'
 
@@ -126,7 +127,7 @@ users_db_to_file:
 ##################
 
 phpstan:
-	${DOCKER_COMPOSE_PHP_FPM_EXEC} vendor/bin/phpstan analyse -c phpstan.neon; \
+	${DOCKER_COMPOSE_PHP_FPM_EXEC} vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=${PHPSTAN_MEMORY_LIMIT}; \
  	${DOCKER_COMPOSE_PHP_FPM_EXEC} vendor/bin/phpstan clear-result-cache
 
 deptrac:

--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,7 @@
 <?php
 
 use App\Kernel;
+use App\Utils\DateTimeUtils;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
@@ -11,6 +12,8 @@ if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
 return function (array $context) {
+    DateTimeUtils::configureServerTimezone($context['TZ'] ?? getenv('TZ'));
+
     $env = is_string($context['APP_ENV']) ? $context['APP_ENV'] : 'prod';
     $kernel = new Kernel($env, (bool) $context['APP_DEBUG']);
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -82,7 +82,7 @@ Run the following before pushing to avoid CI failures:
 
 ```bash
 vendor/bin/php-cs-fixer fix
-vendor/bin/phpstan analyse --no-progress
+vendor/bin/phpstan analyse --no-progress --memory-limit=1G
 vendor/bin/phpunit --no-progress
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,7 +15,7 @@ runs:
 
 - `php bin/console lint:twig`
 - `vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no`
-- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
+- `vendor/bin/phpstan analyse --no-progress --memory-limit=${PHPSTAN_MEMORY_LIMIT:-1G}`
 - `vendor/bin/phpunit --no-progress`
 - `pnpm build`
 
@@ -44,7 +44,7 @@ vendor/bin/php-cs-fixer fix --dry-run --diff
 vendor/bin/php-cs-fixer fix
 
 # Static analysis (level 10)
-vendor/bin/phpstan analyse --no-progress
+vendor/bin/phpstan analyse --no-progress --memory-limit=1G
 
 # Unit and functional tests
 vendor/bin/phpunit --no-progress
@@ -60,7 +60,7 @@ Three jobs run automatically on every PR and on every push to `master`:
 | Job            | Command                                         |
 |----------------|-------------------------------------------------|
 | PHP CS Fixer   | `vendor/bin/php-cs-fixer fix --dry-run --diff`  |
-| PHPStan        | `vendor/bin/phpstan analyse --no-progress`       |
+| PHPStan        | `vendor/bin/phpstan analyse --no-progress --memory-limit=1G` |
 | PHPUnit        | `vendor/bin/phpunit --no-progress` (PHP 8.4 + 8.5) |
 
 All three must pass before a PR can be merged. See `.github/workflows/ci.yml` for the full configuration.

--- a/public/index.php
+++ b/public/index.php
@@ -1,10 +1,13 @@
 <?php
 
 use App\Kernel;
+use App\Utils\DateTimeUtils;
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
 return function (array $context) {
+    DateTimeUtils::configureServerTimezone($context['TZ'] ?? getenv('TZ'));
+
     $envRaw = $context['APP_ENV'] ?? 'dev';
     $env = is_string($envRaw) ? $envRaw : 'dev';
     if (!in_array($env, ['dev', 'test', 'prod'], true)) {

--- a/src/Controller/ServerController.php
+++ b/src/Controller/ServerController.php
@@ -72,6 +72,7 @@ class ServerController extends AbstractController
 
             foreach ($result['req'] as &$value) {
                 unset($value['date']);
+                unset($value['label']);
             }
 
             $allPoints = [];
@@ -87,6 +88,7 @@ class ServerController extends AbstractController
                 foreach ($result['req_per_sec']['data'] as &$value) {
                     if ($value['parsed_hostname'] === '_') {
                         unset($value['date']);
+                        unset($value['label']);
                         unset($value['parsed_hostname']);
                         unset($value['hostname']);
 
@@ -101,12 +103,14 @@ class ServerController extends AbstractController
 
                 foreach ($result['req_per_sec'] as &$value) {
                     unset($value['date']);
+                    unset($value['label']);
                     unset($value['parsed_hostname']);
                 }
             }
 
             foreach ($result['statuses']['data'] as &$value) {
                 unset($value['date']);
+                unset($value['label']);
             }
 
             $result['success'] = 'true';
@@ -515,6 +519,7 @@ class ServerController extends AbstractController
             $data[] = [
                 'created_at' => $createdAt,
                 'date' => DateTimeUtils::chartDateFromStorageDateTime($createdAt),
+                'label' => DateTimeUtils::chartLabelFromStorageDateTime($createdAt),
                 'error_code' => $statusCode,
                 'error_count' => $row['cnt'],
             ];
@@ -569,10 +574,12 @@ class ServerController extends AbstractController
             $hostname = is_string($item['hostname']) ? $item['hostname'] : '';
             $reqPerSec = is_numeric($item['req_per_sec']) ? (float) $item['req_per_sec'] : 0.0;
             $date = DateTimeUtils::chartDateFromStorageDateTime($createdAt);
+            $label = DateTimeUtils::chartLabelFromStorageDateTime($createdAt);
             $parsedHostname = '_' . preg_replace('/\W/', '_', $hostname);
 
             $rpqData[$date][] = [
                 'created_at' => $createdAt,
+                'label' => $label,
                 'hostname' => $hostname,
                 'parsed_hostname' => $parsedHostname,
                 'req_per_sec' => number_format($reqPerSec, 2, '.', ''),
@@ -609,9 +616,11 @@ class ServerController extends AbstractController
                 $createdAt = is_string($item['created_at']) ? $item['created_at'] : '';
                 $reqPerSec = is_numeric($item['req_per_sec']) ? (float) $item['req_per_sec'] : 0.0;
                 $date = DateTimeUtils::chartDateFromStorageDateTime($createdAt);
+                $label = DateTimeUtils::chartLabelFromStorageDateTime($createdAt);
 
                 $rpqData[$date][] = [
                     'created_at' => $createdAt,
+                    'label' => $label,
                     'hostname' => '_',
                     'parsed_hostname' => '_',
                     'req_per_sec' => number_format($reqPerSec, 2, '.', ''),
@@ -670,7 +679,11 @@ class ServerController extends AbstractController
         $result = [];
         foreach ($data as $item) {
             $createdAt = is_string($item['created_at']) ? $item['created_at'] : '';
-            $row = ['created_at' => $createdAt, 'date' => DateTimeUtils::chartDateFromStorageDateTime($createdAt)];
+            $row = [
+                'created_at' => $createdAt,
+                'date' => DateTimeUtils::chartDateFromStorageDateTime($createdAt),
+                'label' => DateTimeUtils::chartLabelFromStorageDateTime($createdAt),
+            ];
 
             foreach (['90', '95', '99', '100'] as $percent) {
                 $raw = $item['req_time_' . $percent] ?? null;

--- a/src/Utils/DateTimeUtils.php
+++ b/src/Utils/DateTimeUtils.php
@@ -40,6 +40,11 @@ final class DateTimeUtils
         );
     }
 
+    public static function chartLabelFromStorageDateTime(string $value): string
+    {
+        return self::formatStorageDateTimeForServer($value, 'Y-m-d H:i');
+    }
+
     public static function storageDateTimeAgo(string $period, string $format = self::DEFAULT_DATETIME_FORMAT): string
     {
         try {
@@ -56,6 +61,21 @@ final class DateTimeUtils
         return (new DateTimeImmutable('@' . $timestamp))
             ->setTimezone(self::serverTimezone())
             ->format($format);
+    }
+
+    public static function configureServerTimezone(mixed $value): void
+    {
+        if (!is_string($value) || $value === '') {
+            return;
+        }
+
+        try {
+            new DateTimeZone($value);
+        } catch (Exception) {
+            return;
+        }
+
+        date_default_timezone_set($value);
     }
 
     private static function parseStorageDateTime(string $value): ?DateTimeImmutable

--- a/templates/server.html.twig
+++ b/templates/server.html.twig
@@ -22,6 +22,11 @@
                     </div>
                     <script type="text/javascript">
                         document.addEventListener('DOMContentLoaded', () => {
+                        const reqTimeLabels = [
+                            {% for item in req %}
+                            "{{ item.label|e('js') }}"{{ not loop.last ? ',' : '' }}
+                            {% endfor %}
+                        ];
                         const reqTimeSeries = [
                             {
                                 label: 'Max request time',
@@ -29,7 +34,7 @@
                                 hidden: true,
                                 data: [
                                     {% for item in req %}
-                                    {x: new Date({{ item.date }}), y: {{ item.req_time_100 }} }{{ not loop.last ? ',' : '' }}
+                                    {{ item.req_time_100 }}{{ not loop.last ? ',' : '' }}
                                     {% endfor %}
                                 ],
                             },
@@ -38,7 +43,7 @@
                                 color: '#C38630',
                                 data: [
                                     {% for item in req %}
-                                    {x: new Date({{ item.date }}), y: {{ item.req_time_99 }} }{{ not loop.last ? ',' : '' }}
+                                    {{ item.req_time_99 }}{{ not loop.last ? ',' : '' }}
                                     {% endfor %}
                                 ],
                             },
@@ -47,7 +52,7 @@
                                 color: '#700193',
                                 data: [
                                     {% for item in req %}
-                                    {x: new Date({{ item.date }}), y: {{ item.req_time_95 }} }{{ not loop.last ? ',' : '' }}
+                                    {{ item.req_time_95 }}{{ not loop.last ? ',' : '' }}
                                     {% endfor %}
                                 ],
                             },
@@ -56,7 +61,7 @@
                                 color: '#39A3B9',
                                 data: [
                                     {% for item in req %}
-                                    {x: new Date({{ item.date }}), y: {{ item.req_time_90 }} }{{ not loop.last ? ',' : '' }}
+                                    {{ item.req_time_90 }}{{ not loop.last ? ',' : '' }}
                                     {% endfor %}
                                 ],
                             },
@@ -65,13 +70,14 @@
                                 color: '#e24a14',
                                 data: [
                                     {% for item in req %}
-                                    {x: new Date({{ item.date }}), y: {{ req_time_border }} }{{ not loop.last ? ',' : '' }}
+                                    {{ req_time_border }}{{ not loop.last ? ',' : '' }}
                                     {% endfor %}
                                 ],
                             },
                         ];
 
-                        window.PinboardCharts.renderTimeSeriesChart('req-time-chart', {
+                        window.PinboardCharts.renderCategoryChart('req-time-chart', {
+                            labels: reqTimeLabels,
                             series: reqTimeSeries,
                         });
                         });
@@ -94,7 +100,7 @@
                         const rpsChartData = [];
                         {% for date, item in req_per_sec.data %}
                         rpsChartData.push({
-                            x: new Date({{ date }})
+                            label: "{{ item|first.label|e('js') }}"
                             {% for iter in item %}
                             , rps{{ iter.parsed_hostname }}: {{ iter.req_per_sec }}
                             {% endfor %}
@@ -106,12 +112,13 @@
                             {
                                 label: "{{ host == '_' ? 'Total requests per second at all hosts' : 'Requests per second at host ' ~ keydata.host }}",
                                 color: "#{{ keydata.color }}",
-                                data: rpsChartData.map((point) => ({x: point.x, y: point['rps{{ host }}'] ?? 0})),
+                                data: rpsChartData.map((point) => point['rps{{ host }}'] ?? 0),
                             }{{ not loop.last ? ',' : '' }}
                             {% endfor %}
                         ];
 
-                        window.PinboardCharts.renderTimeSeriesChart('req-per-sec-chart', {
+                        window.PinboardCharts.renderCategoryChart('req-per-sec-chart', {
+                            labels: rpsChartData.map((point) => point.label),
                             series: rpsSeries,
                         });
                         });
@@ -139,7 +146,13 @@
                     </div>
                     <script type="text/javascript">
                         document.addEventListener('DOMContentLoaded', () => {
-                        window.PinboardCharts.renderTimeSeriesChart('mem-usage-chart', {
+                        const memUsageLabels = [
+                            {% for item in req %}
+                            "{{ item.label|e('js') }}"{{ not loop.last ? ',' : '' }}
+                            {% endfor %}
+                        ];
+                        window.PinboardCharts.renderCategoryChart('mem-usage-chart', {
+                            labels: memUsageLabels,
                             series: [
                                 {
                                     label: 'Max memory peak usage',
@@ -147,7 +160,7 @@
                                     hidden: true,
                                     data: [
                                         {% for item in req %}
-                                        {x: new Date({{ item.date }}), y: {{ item.mem_peak_usage_100 }} }{{ not loop.last ? ',' : '' }}
+                                        {{ item.mem_peak_usage_100 }}{{ not loop.last ? ',' : '' }}
                                         {% endfor %}
                                     ],
                                 },
@@ -156,7 +169,7 @@
                                     color: '#C38630',
                                     data: [
                                         {% for item in req %}
-                                        {x: new Date({{ item.date }}), y: {{ item.mem_peak_usage_99 }} }{{ not loop.last ? ',' : '' }}
+                                        {{ item.mem_peak_usage_99 }}{{ not loop.last ? ',' : '' }}
                                         {% endfor %}
                                     ],
                                 },
@@ -165,7 +178,7 @@
                                     color: '#700193',
                                     data: [
                                         {% for item in req %}
-                                        {x: new Date({{ item.date }}), y: {{ item.mem_peak_usage_95 }} }{{ not loop.last ? ',' : '' }}
+                                        {{ item.mem_peak_usage_95 }}{{ not loop.last ? ',' : '' }}
                                         {% endfor %}
                                     ],
                                 },
@@ -174,7 +187,7 @@
                                     color: '#39A3B9',
                                     data: [
                                         {% for item in req %}
-                                        {x: new Date({{ item.date }}), y: {{ item.mem_peak_usage_90 }} }{{ not loop.last ? ',' : '' }}
+                                        {{ item.mem_peak_usage_90 }}{{ not loop.last ? ',' : '' }}
                                         {% endfor %}
                                     ],
                                 },
@@ -202,7 +215,13 @@
                     </div>
                     <script type="text/javascript">
                         document.addEventListener('DOMContentLoaded', () => {
-                        window.PinboardCharts.renderTimeSeriesChart('cpu-usage-chart', {
+                        const cpuUsageLabels = [
+                            {% for item in req %}
+                            "{{ item.label|e('js') }}"{{ not loop.last ? ',' : '' }}
+                            {% endfor %}
+                        ];
+                        window.PinboardCharts.renderCategoryChart('cpu-usage-chart', {
+                            labels: cpuUsageLabels,
                             series: [
                                 {
                                     label: 'Max CPU peak usage',
@@ -210,7 +229,7 @@
                                     hidden: true,
                                     data: [
                                         {% for item in req %}
-                                        {x: new Date({{ item.date }}), y: {{ item.cpu_peak_usage_100 }} }{{ not loop.last ? ',' : '' }}
+                                        {{ item.cpu_peak_usage_100 }}{{ not loop.last ? ',' : '' }}
                                         {% endfor %}
                                     ],
                                 },
@@ -219,7 +238,7 @@
                                     color: '#C38630',
                                     data: [
                                         {% for item in req %}
-                                        {x: new Date({{ item.date }}), y: {{ item.cpu_peak_usage_99 }} }{{ not loop.last ? ',' : '' }}
+                                        {{ item.cpu_peak_usage_99 }}{{ not loop.last ? ',' : '' }}
                                         {% endfor %}
                                     ],
                                 },
@@ -228,7 +247,7 @@
                                     color: '#700193',
                                     data: [
                                         {% for item in req %}
-                                        {x: new Date({{ item.date }}), y: {{ item.cpu_peak_usage_95 }} }{{ not loop.last ? ',' : '' }}
+                                        {{ item.cpu_peak_usage_95 }}{{ not loop.last ? ',' : '' }}
                                         {% endfor %}
                                     ],
                                 },
@@ -237,7 +256,7 @@
                                     color: '#39A3B9',
                                     data: [
                                         {% for item in req %}
-                                        {x: new Date({{ item.date }}), y: {{ item.cpu_peak_usage_90 }} }{{ not loop.last ? ',' : '' }}
+                                        {{ item.cpu_peak_usage_90 }}{{ not loop.last ? ',' : '' }}
                                         {% endfor %}
                                     ],
                                 },
@@ -270,18 +289,19 @@
                         const statusChartData = [];
                         {% for item in statuses.data %}
                         statusChartData.push({
-                            x: new Date({{ item.date }})
+                            label: "{{ item.label|e('js') }}"
                             , status{{ item.error_code }}: {{ item.error_count }}
                         });
                         {% endfor %}
 
-                        window.PinboardCharts.renderTimeSeriesChart('statuses-chart', {
+                        window.PinboardCharts.renderCategoryChart('statuses-chart', {
+                            labels: statusChartData.map((point) => point.label),
                             series: [
                                 {% for code, color in statuses.codes %}
                                 {
                                     label: "Status {{ code }}",
                                     color: "#{{ color }}",
-                                    data: statusChartData.map((point) => ({x: point.x, y: point['status{{ code }}'] ?? 0})),
+                                    data: statusChartData.map((point) => point['status{{ code }}'] ?? 0),
                                 }{{ not loop.last ? ',' : '' }}
                                 {% endfor %}
                             ],

--- a/tests/Unit/Utils/DateTimeUtilsTest.php
+++ b/tests/Unit/Utils/DateTimeUtilsTest.php
@@ -38,9 +38,32 @@ final class DateTimeUtilsTest extends TestCase
         );
     }
 
+    public function testFormatsChartLabelInServerTimezone(): void
+    {
+        self::assertSame(
+            '2026-07-20 15:34',
+            DateTimeUtils::chartLabelFromStorageDateTime('2026-07-20 12:34:56')
+        );
+    }
+
     public function testFormatsUnixTimestampInServerTimezone(): void
     {
         self::assertSame('03:00:00', DateTimeUtils::formatUnixTimestampForServer(0));
+    }
+
+    public function testConfiguresServerTimezone(): void
+    {
+        DateTimeUtils::configureServerTimezone('Asia/Yekaterinburg');
+
+        self::assertSame('Asia/Yekaterinburg', date_default_timezone_get());
+        self::assertSame('05:00:00', DateTimeUtils::formatUnixTimestampForServer(0));
+    }
+
+    public function testIgnoresInvalidServerTimezone(): void
+    {
+        DateTimeUtils::configureServerTimezone('invalid/timezone');
+
+        self::assertSame('Europe/Moscow', date_default_timezone_get());
     }
 
     public function testInvalidStorageDateTimeFallsBackToOriginalValue(): void


### PR DESCRIPTION
## Summary
- configure PHP timezone from TZ during web and console bootstrap
- render overview chart labels as server-formatted strings instead of browser-local Date objects
- keep overview JSON output unchanged by stripping internal chart labels

## Tests
- /usr/bin/php85 -l src/Utils/DateTimeUtils.php
- /usr/bin/php85 -l public/index.php
- /usr/bin/php85 -l bin/console
- /usr/bin/php85 -l src/Controller/ServerController.php
- docker exec pinboard-test-php-fpm php bin/console lint:twig
- docker exec pinboard-test-php-fpm php vendor/bin/phpunit tests/Unit/Utils/DateTimeUtilsTest.php --no-progress
- docker exec pinboard-test-php-fpm php vendor/bin/php-cs-fixer fix --dry-run --diff
- docker exec pinboard-test-php-fpm php vendor/bin/phpstan analyse --no-progress --memory-limit=1G
- docker exec -u root pinboard-test-node sh -lc 'cd /var/www && corepack enable && pnpm build'