### PR TITLE
ci: pin third-party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # Build the exact production image on every PR (never pushed). This is
       # the check that catches frontend-toolchain breakage and apk pin rot
@@ -53,7 +53,7 @@ jobs:
       # shared with the release workflow, so a green PR makes the release
       # build nearly free.
       - name: Build production image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.pinboard
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.4'
           extensions: intl, pdo_mysql
@@ -117,7 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.4'
           extensions: intl, pdo_mysql
@@ -157,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: intl, pdo_mysql
@@ -183,7 +183,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.4'
           extensions: intl, pdo_mysql
@@ -204,7 +204,7 @@ jobs:
         run: vendor/bin/phpunit --no-progress --coverage-clover coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,9 +22,9 @@ jobs:
         with:
           ref: ${{ inputs.release-tag != '' && inputs.release-tag || github.ref }}
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -40,7 +40,7 @@ jobs:
       # pushed — a broken image must never reach Docker Hub. Mirrors the smoke
       # gate in pinba_engine's publish workflow.
       - name: Build image for smoke test
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.pinboard
@@ -72,7 +72,7 @@ jobs:
         run: docker compose -f docker-compose.public.yml logs --tail 200 || true
 
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.pinboard

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: rp
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,17 +70,23 @@ Full details: `docs/contributing.md` (PR workflow) and `docs/releasing.md` (rele
 
 ## GitHub Actions
 
-- When adding or editing a workflow, pin every third-party action to its current
-  major version. Always verify the latest release before committing instead of
-  reusing a version from memory or copying an old example, e.g.:
+- When adding or editing a workflow, verify the current latest release before
+  committing instead of reusing a version from memory or copying an old example,
+  e.g.:
 
   ```bash
-  gh api repos/actions/checkout/releases/latest --jq .tag_name
+  gh api repos/docker/build-push-action/releases/latest --jq .tag_name
   ```
 
-- Reference actions by their major tag (e.g. `actions/checkout@v7`) so they track
-  the latest compatible patch, and never introduce a version older than what the
-  rest of the repository (or the sibling Pinba repositories) already uses.
+- Reference first-party GitHub actions by their major tag (e.g.
+  `actions/checkout@v7`) so they track the latest compatible patch.
+- Reference third-party actions by full commit SHA and add the verified release
+  tag as a trailing comment, e.g.
+  `docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0`.
+  This is required to keep CodeQL `actions/unpinned-tag` clean. Resolve annotated
+  tags to the target commit SHA, not the tag object SHA.
+- Never introduce a version older than what the rest of the repository (or the
+  sibling Pinba repositories) already uses.
 - Dependabot (`.github/dependabot.yml`) opens grouped `ci:` PRs for action bumps;
   keep all workflows (`ci.yml`, `codeql.yml`, `docker.yml`, `release-please.yml`)
   on the same current majors.


### PR DESCRIPTION
## Summary
- pin third-party GitHub Actions to verified latest release commit SHAs
- keep verified release tags in trailing comments
- document the rule in AGENTS.md so future workflow edits keep CodeQL actions/unpinned-tag clean

## Verified via GitHub API
- docker/setup-buildx-action v4.2.0 -> bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
- docker/login-action v4.4.0 -> af1e73f918a031802d376d3c8bbc3fe56130a9b0
- docker/build-push-action v7.3.0 -> 53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
- shivammathur/setup-php 2.37.2 -> f3e473d116dcccaddc5834248c87452386958240
- codecov/codecov-action v7.0.0 -> fb8b3582c8e4def4969c97caa2f19720cb33a72f
- googleapis/release-please-action v5.0.0 -> 45996ed1f6d02564a971a2fa1b5860e934307cf7

## Checks
- rg -n "uses:" .github/workflows
- rg -n "docker/.*@v|shivammathur/.*@v|codecov/.*@v|googleapis/.*@v" .github/workflows
- git diff --check