### PR TITLE
fix(time): correct aggregate page timestamps

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,6 @@
 <?php
 
 use App\Kernel;
-use App\Utils\DateTimeUtils;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
@@ -12,8 +11,6 @@ if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
 return function (array $context) {
-    DateTimeUtils::configureServerTimezone($context['TZ'] ?? getenv('TZ'));
-
     $env = is_string($context['APP_ENV']) ? $context['APP_ENV'] : 'prod';
     $kernel = new Kernel($env, (bool) $context['APP_DEBUG']);
 

--- a/public/index.php
+++ b/public/index.php
@@ -1,13 +1,10 @@
 <?php
 
 use App\Kernel;
-use App\Utils\DateTimeUtils;
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
 return function (array $context) {
-    DateTimeUtils::configureServerTimezone($context['TZ'] ?? getenv('TZ'));
-
     $envRaw = $context['APP_ENV'] ?? 'dev';
     $env = is_string($envRaw) ? $envRaw : 'dev';
     if (!in_array($env, ['dev', 'test', 'prod'], true)) {

--- a/src/Controller/ServerController.php
+++ b/src/Controller/ServerController.php
@@ -777,6 +777,7 @@ class ServerController extends AbstractController
                     $result[$date] = [];
                 }
 
+                $result[$date]['label'] = $this->formatChartTimeLabel($createdAt);
                 $result[$date][$reqField] = $formatted;
             }
 
@@ -837,6 +838,7 @@ class ServerController extends AbstractController
             if (!isset($result[$date])) {
                 $result[$date] = [];
             }
+            $result[$date]['label'] = $this->formatChartTimeLabel($createdAt);
             $result[$date][$key] = $item[$valueField];
         }
 
@@ -844,6 +846,13 @@ class ServerController extends AbstractController
             'timers' => !empty($data) ? $timers : [],
             'values' => !empty($data) ? $result : []
         ];
+    }
+
+    private function formatChartTimeLabel(string $createdAt): string
+    {
+        return preg_match('/^\d{4}-\d{2}-\d{2} (\d{2}:\d{2})/', $createdAt, $matches) === 1
+            ? $matches[1]
+            : $createdAt;
     }
 
     /** @return list<array<string, mixed>> */
@@ -891,7 +900,7 @@ class ServerController extends AbstractController
         $rows = [];
         foreach ($data as $item) {
             $createdAt = is_string($item['created_at']) ? $item['created_at'] : '';
-            $item['created_at_format'] = DateTimeUtils::formatStorageDateTimeForServer($createdAt);
+            $item['created_at_format'] = $createdAt;
             $item['script_name'] = Utils::urlDecode(is_string($item['script_name']) ? $item['script_name'] : '');
             $parsed = Utils::parseRequestTags($item);
             $rows[] = is_array($parsed) ? $parsed : $item;
@@ -968,7 +977,7 @@ class ServerController extends AbstractController
         $rows = [];
         foreach ($data as $item) {
             $createdAt = is_string($item['created_at']) ? $item['created_at'] : '';
-            $item['created_at_format'] = DateTimeUtils::formatStorageDateTimeForServer($createdAt);
+            $item['created_at_format'] = $createdAt;
             $item['script_name'] = Utils::urlDecode(is_string($item['script_name']) ? $item['script_name'] : '');
             $item['req_time'] = number_format(is_numeric($item['req_time']) ? (float) $item['req_time'] * 1000 : 0.0, 0, '.', ',');
             $parsed = Utils::parseRequestTags($item);
@@ -1075,7 +1084,7 @@ class ServerController extends AbstractController
         $rows = [];
         foreach ($data as $item) {
             $createdAt = is_string($item['created_at']) ? $item['created_at'] : '';
-            $item['created_at_format'] = DateTimeUtils::formatStorageDateTimeForServer($createdAt);
+            $item['created_at_format'] = $createdAt;
             $item['script_name'] = Utils::urlDecode(is_string($item['script_name']) ? $item['script_name'] : '');
             $item['cpu_peak_usage'] = number_format(is_numeric($item['cpu_peak_usage']) ? (float) $item['cpu_peak_usage'] : 0.0, 3);
             $parsed = Utils::parseRequestTags($item);
@@ -1130,7 +1139,7 @@ class ServerController extends AbstractController
         $rows = [];
         foreach ($data as $item) {
             $createdAt = is_string($item['created_at']) ? $item['created_at'] : '';
-            $item['created_at_format'] = DateTimeUtils::formatStorageDateTimeForServer($createdAt);
+            $item['created_at_format'] = $createdAt;
             $item['script_name'] = Utils::urlDecode(is_string($item['script_name']) ? $item['script_name'] : '');
             $item['mem_peak_usage'] = number_format(is_numeric($item['mem_peak_usage']) ? (float) $item['mem_peak_usage'] : 0.0, 0, '.', ',');
             $parsed = Utils::parseRequestTags($item);

--- a/src/Controller/TimerController.php
+++ b/src/Controller/TimerController.php
@@ -48,7 +48,7 @@ class TimerController extends AbstractController
         $request['script_name'] = Utils::urlDecode(is_string($request['script_name']) ? $request['script_name'] : '');
         if ($type === 'req_time') {
             $createdAt = is_string($request['created_at'] ?? null) ? $request['created_at'] : '';
-            $request['created_at_format'] = DateTimeUtils::formatStorageDateTimeForServer($createdAt);
+            $request['created_at_format'] = $createdAt;
         } elseif (is_numeric($request['timestamp'] ?? null)) {
             $request['timestamp_format'] = DateTimeUtils::formatUnixTimestampForServer((int) $request['timestamp']);
         }

--- a/src/Utils/DateTimeUtils.php
+++ b/src/Utils/DateTimeUtils.php
@@ -63,21 +63,6 @@ final class DateTimeUtils
             ->format($format);
     }
 
-    public static function configureServerTimezone(mixed $value): void
-    {
-        if (!is_string($value) || $value === '') {
-            return;
-        }
-
-        try {
-            new DateTimeZone($value);
-        } catch (Exception) {
-            return;
-        }
-
-        date_default_timezone_set($value);
-    }
-
     private static function parseStorageDateTime(string $value): ?DateTimeImmutable
     {
         if ($value === '') {
@@ -98,6 +83,15 @@ final class DateTimeUtils
 
     private static function serverTimezone(): DateTimeZone
     {
+        $timezone = getenv('TZ');
+        if (is_string($timezone) && $timezone !== '') {
+            try {
+                return new DateTimeZone($timezone);
+            } catch (Exception) {
+                // Fall back to PHP's configured timezone below.
+            }
+        }
+
         return new DateTimeZone(date_default_timezone_get());
     }
 }

--- a/src/Utils/DateTimeUtils.php
+++ b/src/Utils/DateTimeUtils.php
@@ -42,7 +42,7 @@ final class DateTimeUtils
 
     public static function chartLabelFromStorageDateTime(string $value): string
     {
-        return self::formatStorageDateTimeForServer($value, 'Y-m-d H:i');
+        return self::formatStorageDateTimeForServer($value, 'H:i');
     }
 
     public static function storageDateTimeAgo(string $period, string $format = self::DEFAULT_DATETIME_FORMAT): string

--- a/templates/timers.html.twig
+++ b/templates/timers.html.twig
@@ -32,14 +32,15 @@
                             const {{ chart.field }}ChartData = [];
                             {% for date, item in chart.data.values %}
                             {{ chart.field }}ChartData.push({
-                                x: new Date({{ date }})
+                                label: "{{ item.label|e('js') }}"
                                 {% for timer in chart.data.timers %}
                                 , '{{ timer }}': {{ item[timer] is defined and item[timer] > 0 ? item[timer] : 0 }}
                                 {% endfor %}
                             });
                             {% endfor %}
 
-                            const {{ chart.field }}Chart = window.PinboardCharts.renderTimeSeriesChart('{{ chart.field }}-chart', {
+                            const {{ chart.field }}Chart = window.PinboardCharts.renderCategoryChart('{{ chart.field }}-chart', {
+                                labels: {{ chart.field }}ChartData.map((point) => point.label),
                                 stacked: true,
                                 series: [
                                     {% for timer in chart.data.timers %}
@@ -47,7 +48,7 @@
                                         label: "{{ request_graphs[timer] is defined ? request_graphs[timer]['title'] : timer }}",
                                         color: "{{ request_graphs[timer] is defined ? '#39A3B9' : '#729462' }}",
                                         fill: true,
-                                        data: {{ chart.field }}ChartData.map((point) => ({x: point.x, y: point['{{ timer }}'] ?? 0})),
+                                        data: {{ chart.field }}ChartData.map((point) => point['{{ timer }}'] ?? 0),
                                     }{{ not loop.last ? ',' : '' }}
                                     {% endfor %}
                                 ],

--- a/tests/Unit/Utils/DateTimeUtilsTest.php
+++ b/tests/Unit/Utils/DateTimeUtilsTest.php
@@ -41,7 +41,7 @@ final class DateTimeUtilsTest extends TestCase
     public function testFormatsChartLabelInServerTimezone(): void
     {
         self::assertSame(
-            '2026-07-20 15:34',
+            '15:34',
             DateTimeUtils::chartLabelFromStorageDateTime('2026-07-20 12:34:56')
         );
     }

--- a/tests/Unit/Utils/DateTimeUtilsTest.php
+++ b/tests/Unit/Utils/DateTimeUtilsTest.php
@@ -10,16 +10,24 @@ use PHPUnit\Framework\TestCase;
 final class DateTimeUtilsTest extends TestCase
 {
     private string $originalTimezone = 'UTC';
+    private string|false $originalEnvironmentTimezone = false;
 
     protected function setUp(): void
     {
         $this->originalTimezone = date_default_timezone_get();
+        $this->originalEnvironmentTimezone = getenv('TZ');
         date_default_timezone_set('Europe/Moscow');
+        putenv('TZ=Europe/Moscow');
     }
 
     protected function tearDown(): void
     {
         date_default_timezone_set($this->originalTimezone);
+        if ($this->originalEnvironmentTimezone === false) {
+            putenv('TZ');
+        } else {
+            putenv('TZ=' . $this->originalEnvironmentTimezone);
+        }
     }
 
     public function testFormatsStorageDateTimeInServerTimezone(): void
@@ -51,19 +59,20 @@ final class DateTimeUtilsTest extends TestCase
         self::assertSame('03:00:00', DateTimeUtils::formatUnixTimestampForServer(0));
     }
 
-    public function testConfiguresServerTimezone(): void
+    public function testFormatsWithTimezoneFromEnvironment(): void
     {
-        DateTimeUtils::configureServerTimezone('Asia/Yekaterinburg');
+        putenv('TZ=Asia/Yekaterinburg');
 
-        self::assertSame('Asia/Yekaterinburg', date_default_timezone_get());
+        self::assertSame('Europe/Moscow', date_default_timezone_get());
         self::assertSame('05:00:00', DateTimeUtils::formatUnixTimestampForServer(0));
     }
 
-    public function testIgnoresInvalidServerTimezone(): void
+    public function testInvalidEnvironmentTimezoneFallsBackToPhpDefault(): void
     {
-        DateTimeUtils::configureServerTimezone('invalid/timezone');
+        putenv('TZ=invalid/timezone');
 
         self::assertSame('Europe/Moscow', date_default_timezone_get());
+        self::assertSame('03:00:00', DateTimeUtils::formatUnixTimestampForServer(0));
     }
 
     public function testInvalidStorageDateTimeFallsBackToOriginalValue(): void


### PR DESCRIPTION
Summary
- Keep overview chart labels compact: time only, without the date.
- Stop applying an extra server-timezone shift to aggregate detail timestamps that are already stored/displayed as local aggregate time.
- Render timers charts with server-side time labels instead of browser Date parsing.
- Read TZ inside DateTimeUtils formatting without changing the global PHP timezone for web or console entrypoints.

Checks
- /usr/bin/php85 -l public/index.php
- /usr/bin/php85 -l bin/console
- /usr/bin/php85 -l src/Utils/DateTimeUtils.php
- /usr/bin/php85 -l src/Controller/ServerController.php
- /usr/bin/php85 -l src/Controller/TimerController.php
- /usr/bin/php85 vendor/bin/phpunit tests/Unit/Utils/DateTimeUtilsTest.php --no-progress
- docker exec pinboard-test-php-fpm php bin/console lint:twig templates/timers.html.twig
- docker exec pinboard-test-php-fpm php vendor/bin/phpstan analyse --no-progress --memory-limit=1G
- docker exec pinboard-test-php-fpm php vendor/bin/php-cs-fixer fix --dry-run --diff
- docker exec pinboard-test-node sh -lc "cd /var/www && COREPACK_HOME=/tmp/corepack corepack pnpm build"