### PR TITLE
chore(deps): update webpack encore

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
         "@babel/core": "^8.0.1",
         "@babel/preset-env": "^8.0.2",
         "@popperjs/core": "^2.11.8",
-        "@symfony/webpack-encore": "^7.1.0",
+        "@symfony/webpack-encore": "^7.2.0",
         "babel-plugin-polyfill-corejs3": "^1.0.0",
         "bootstrap": "^5.3.3",
         "core-js": "^3.49.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^2.11.8
         version: 2.11.8
       '@symfony/webpack-encore':
-        specifier: ^7.1.0
-        version: 7.1.0(@babel/core@8.0.1)(@babel/preset-env@8.0.2(@babel/core@8.0.1))(postcss@8.5.17)(sass-loader@17.0.0(sass@1.102.0)(webpack@5.109.0))(sass@1.102.0)(webpack-cli@7.2.1)(webpack-notifier@1.15.0)(webpack@5.109.0)
+        specifier: ^7.2.0
+        version: 7.2.0(@babel/core@8.0.1)(@babel/preset-env@8.0.2(@babel/core@8.0.1))(postcss@8.5.23)(sass-loader@17.0.0(sass@1.102.0)(webpack@5.109.0))(sass@1.102.0)(webpack-cli@7.2.1)(webpack-notifier@1.15.0)(webpack@5.109.0)
       babel-plugin-polyfill-corejs3:
         specifier: ^1.0.0
         version: 1.0.0(@babel/core@8.0.1)
@@ -56,7 +56,7 @@ importers:
         version: 17.0.0(sass@1.102.0)(webpack@5.109.0)
       webpack:
         specifier: ^5.109.0
-        version: 5.109.0(postcss@8.5.17)(webpack-cli@7.2.1)
+        version: 5.109.0(postcss@8.5.23)(webpack-cli@7.2.1)
       webpack-cli:
         specifier: ^7.2.1
         version: 7.2.1(json5@2.2.3)(webpack@5.109.0)
@@ -656,8 +656,8 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
-  '@symfony/webpack-encore@7.1.0':
-    resolution: {integrity: sha512-PBRZmv9YtjtA8t8OjhylmauL5y1+QLb+S4NEmHyQ7GMVlVWGvn4KXAia/A7r/m04sF6EoseXKGs45DCCof04TA==}
+  '@symfony/webpack-encore@7.2.0':
+    resolution: {integrity: sha512-rICgGPCGkuZmySw8av72/tvJg8HTs+f49m75fgv8/Rr6SRBHqVUPy8PPPfY7WmDyLIwXhRhDK9wwpb+db224zg==}
     engines: {node: ^22.18.0 || ^24.11.0 || >=26.0}
     hasBin: true
     peerDependencies:
@@ -695,7 +695,7 @@ packages:
       vue-loader: ^17.0.0
       webpack: ^5.82
       webpack-cli: ^6.0.0 || ^7.0.0
-      webpack-dev-server: '*'
+      webpack-dev-server: ^5.1.0 || ^6.0.0
       webpack-notifier: ^1.15.0
     peerDependenciesMeta:
       '@babel/plugin-transform-react-jsx':
@@ -1283,8 +1283,8 @@ packages:
       uglify-js:
         optional: true
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1381,8 +1381,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.17:
-    resolution: {integrity: sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-error@4.0.0:
@@ -2240,7 +2240,7 @@ snapshots:
       error-stack-parser: 2.1.4
       picocolors: 1.1.1
       string-width: 4.2.3
-      webpack: 5.109.0(postcss@8.5.17)(webpack-cli@7.2.1)
+      webpack: 5.109.0(postcss@8.5.23)(webpack-cli@7.2.1)
 
   '@kurkle/color@0.3.4': {}
 
@@ -2303,7 +2303,7 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@symfony/webpack-encore@7.1.0(@babel/core@8.0.1)(@babel/preset-env@8.0.2(@babel/core@8.0.1))(postcss@8.5.17)(sass-loader@17.0.0(sass@1.102.0)(webpack@5.109.0))(sass@1.102.0)(webpack-cli@7.2.1)(webpack-notifier@1.15.0)(webpack@5.109.0)':
+  '@symfony/webpack-encore@7.2.0(@babel/core@8.0.1)(@babel/preset-env@8.0.2(@babel/core@8.0.1))(postcss@8.5.23)(sass-loader@17.0.0(sass@1.102.0)(webpack@5.109.0))(sass@1.102.0)(webpack-cli@7.2.1)(webpack-notifier@1.15.0)(webpack@5.109.0)':
     dependencies:
       '@babel/core': 8.0.1
       '@babel/preset-env': 8.0.2(@babel/core@8.0.1)
@@ -2312,7 +2312,7 @@ snapshots:
       css-loader: 7.1.4(webpack@5.109.0)
       fastest-levenshtein: 1.0.16
       mini-css-extract-plugin: 2.10.2(webpack@5.109.0)
-      minimizer-webpack-plugin: 5.6.1(postcss@8.5.17)(webpack@5.109.0)
+      minimizer-webpack-plugin: 5.6.1(postcss@8.5.23)(webpack@5.109.0)
       picocolors: 1.1.1
       pretty-error: 4.0.0
       resolve-url-loader: 5.0.0
@@ -2320,12 +2320,12 @@ snapshots:
       style-loader: 4.0.0(webpack@5.109.0)
       tapable: 2.3.3
       tmp: 0.2.7
-      webpack: 5.109.0(postcss@8.5.17)(webpack-cli@7.2.1)
+      webpack: 5.109.0(postcss@8.5.23)(webpack-cli@7.2.1)
       webpack-cli: 7.2.1(json5@2.2.3)(webpack@5.109.0)
       webpack-manifest-plugin: 6.0.1(webpack@5.109.0)
       yargs-parser: 21.1.1
     optionalDependencies:
-      postcss: 8.5.17
+      postcss: 8.5.23
       sass: 1.102.0
       sass-loader: 17.0.0(sass@1.102.0)(webpack@5.109.0)
       webpack-notifier: 1.15.0
@@ -2457,7 +2457,7 @@ snapshots:
       '@babel/core': 8.0.1
       find-up: 5.0.0
     optionalDependencies:
-      webpack: 5.109.0(postcss@8.5.17)(webpack-cli@7.2.1)
+      webpack: 5.109.0(postcss@8.5.23)(webpack-cli@7.2.1)
 
   babel-plugin-polyfill-corejs3@1.0.0(@babel/core@8.0.1):
     dependencies:
@@ -2546,16 +2546,16 @@ snapshots:
 
   css-loader@7.1.4(webpack@5.109.0):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.17)
-      postcss: 8.5.17
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.17)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.17)
-      postcss-modules-scope: 3.2.1(postcss@8.5.17)
-      postcss-modules-values: 4.0.0(postcss@8.5.17)
+      icss-utils: 5.1.0(postcss@8.5.23)
+      postcss: 8.5.23
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.23)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.23)
+      postcss-modules-scope: 3.2.1(postcss@8.5.23)
+      postcss-modules-values: 4.0.0(postcss@8.5.23)
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.109.0(postcss@8.5.17)(webpack-cli@7.2.1)
+      webpack: 5.109.0(postcss@8.5.23)(webpack-cli@7.2.1)
 
   css-select@4.3.0:
     dependencies:
@@ -2681,9 +2681,9 @@ snapshots:
       domutils: 2.8.0
       entities: 2.2.0
 
-  icss-utils@5.1.0(postcss@8.5.17):
+  icss-utils@5.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.17
+      postcss: 8.5.23
 
   immutable@5.1.9: {}
 
@@ -2768,19 +2768,19 @@ snapshots:
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.109.0(postcss@8.5.17)(webpack-cli@7.2.1)
+      webpack: 5.109.0(postcss@8.5.23)(webpack-cli@7.2.1)
 
-  minimizer-webpack-plugin@5.6.1(postcss@8.5.17)(webpack@5.109.0):
+  minimizer-webpack-plugin@5.6.1(postcss@8.5.23)(webpack@5.109.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.109.0(postcss@8.5.17)(webpack-cli@7.2.1)
+      webpack: 5.109.0(postcss@8.5.23)(webpack-cli@7.2.1)
     optionalDependencies:
-      postcss: 8.5.17
+      postcss: 8.5.23
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   neo-async@2.6.2: {}
 
@@ -2837,26 +2837,26 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.17):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.17
+      postcss: 8.5.23
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.17):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.23):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.17)
-      postcss: 8.5.17
+      icss-utils: 5.1.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.17):
+  postcss-modules-scope@3.2.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.17
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
 
-  postcss-modules-values@4.0.0(postcss@8.5.17):
+  postcss-modules-values@4.0.0(postcss@8.5.23):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.17)
-      postcss: 8.5.17
+      icss-utils: 5.1.0(postcss@8.5.23)
+      postcss: 8.5.23
 
   postcss-selector-parser@7.1.4:
     dependencies:
@@ -2865,9 +2865,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.17:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2928,7 +2928,7 @@ snapshots:
       adjust-sourcemap-loader: 4.0.0
       convert-source-map: 1.9.0
       loader-utils: 2.0.4
-      postcss: 8.5.17
+      postcss: 8.5.23
       source-map: 0.6.1
 
   resolve@1.22.12:
@@ -2941,7 +2941,7 @@ snapshots:
   sass-loader@17.0.0(sass@1.102.0)(webpack@5.109.0):
     optionalDependencies:
       sass: 1.102.0
-      webpack: 5.109.0(postcss@8.5.17)(webpack-cli@7.2.1)
+      webpack: 5.109.0(postcss@8.5.23)(webpack-cli@7.2.1)
 
   sass@1.102.0:
     dependencies:
@@ -2995,7 +2995,7 @@ snapshots:
 
   style-loader@4.0.0(webpack@5.109.0):
     dependencies:
-      webpack: 5.109.0(postcss@8.5.17)(webpack-cli@7.2.1)
+      webpack: 5.109.0(postcss@8.5.23)(webpack-cli@7.2.1)
 
   supports-color@8.1.1:
     dependencies:
@@ -3058,7 +3058,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.109.0(postcss@8.5.17)(webpack-cli@7.2.1)
+      webpack: 5.109.0(postcss@8.5.23)(webpack-cli@7.2.1)
       webpack-merge: 6.0.1
     optionalDependencies:
       json5: 2.2.3
@@ -3066,7 +3066,7 @@ snapshots:
   webpack-manifest-plugin@6.0.1(webpack@5.109.0):
     dependencies:
       tapable: 2.3.3
-      webpack: 5.109.0(postcss@8.5.17)(webpack-cli@7.2.1)
+      webpack: 5.109.0(postcss@8.5.23)(webpack-cli@7.2.1)
       webpack-sources: 3.5.1
 
   webpack-merge@6.0.1:
@@ -3082,7 +3082,7 @@ snapshots:
 
   webpack-sources@3.5.1: {}
 
-  webpack@5.109.0(postcss@8.5.17)(webpack-cli@7.2.1):
+  webpack@5.109.0(postcss@8.5.23)(webpack-cli@7.2.1):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -3098,7 +3098,7 @@ snapshots:
       events: 3.3.0
       graceful-fs: 4.2.11
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(postcss@8.5.17)(webpack@5.109.0)
+      minimizer-webpack-plugin: 5.6.1(postcss@8.5.23)(webpack@5.109.0)
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3


### PR DESCRIPTION
## Summary
- update @symfony/webpack-encore from 7.1.0 to 7.2.0
- refresh pnpm-lock.yaml so transitive postcss resolves to 8.5.23
- address Dependabot security alert #54 (GHSA-r28c-9q8g-f849) without adding a postcss override

## Findings
- postcss is not a direct dependency; it is pulled through the frontend build toolchain, primarily @symfony/webpack-encore and its css-loader/minimizer-webpack-plugin path
- pnpm outdated showed only @symfony/webpack-encore behind latest
- updating that direct dependency resolves postcss from vulnerable 8.5.17 to patched 8.5.23

## Testing
- pnpm install --frozen-lockfile
- pnpm outdated
- pnpm audit --audit-level high
- pnpm build